### PR TITLE
Clarify ABI v1 action-path scope

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 These docs describe the public SDK contracts; engine internals are private.
 
+Current note: the transport ABI docs below are v1 action-path contracts. They do not define the full long-term mod lifecycle on their own.
+
 - [SDK_DISTRIBUTION.md](SDK_DISTRIBUTION.md)
 - [WASM_ABI_v1.md](WASM_ABI_v1.md)
 - [NATIVE_MOD_ABI_v1.md](NATIVE_MOD_ABI_v1.md)


### PR DESCRIPTION
Document that the current transport ABI references describe only the v1 action path and do not define the full long-term mod lifecycle contract on their own.

## Summary
This PR updates the public SDK docs to clarify the scope of the current ABI documentation.

It explicitly states that the existing transport ABI references are v1 action-path contracts only, and should not be read as the full long-term mod lifecycle model. This keeps the public docs aligned with the architecture freeze being introduced in the engine repo.

## Validation
List what you ran:
- [ ] cargo fmt --all -- --check
- [ ] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [ ] cargo test --workspace --all-features

## freven-sdk dependency
- Does this PR change the pinned `freven-sdk` tag?
  - [x] No
  - [ ] Yes (which tag and why?)

## Notes for reviewers
This is a docs-only clarification. The main thing to verify is wording: the ABI docs should remain accurate for the current v1 action path, while no longer implying they already define the complete long-term mod lifecycle.