### PR TITLE
Introduce freven_guest contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "freven_guest"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "freven_sdk_types"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/freven_api",
+    "crates/freven_guest",
     "crates/freven_sdk_types",
     "crates/freven_std",
 ]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The **engine source is private** and is **not** part of this repository.
 
 Current SDK crates:
 - `freven_api` - stable-ish SDK contracts (pre-1.0)
+- `freven_guest` - canonical transport-agnostic guest contract for runtime-loaded mods
 - `freven_sdk_types` - pure shared SDK types
 - `freven_std` - early stdlib helpers (**unstable**; depend only if you accept breakage)
 
@@ -19,6 +20,7 @@ Use tagged git dependencies until crates.io publishing begins:
 ```toml
 [dependencies]
 freven_api = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_api" }
+freven_guest = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_guest" }
 freven_sdk_types = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_sdk_types" }
 # Optional / unstable:
 # freven_std = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_std" }

--- a/crates/freven_api/README.md
+++ b/crates/freven_api/README.md
@@ -13,6 +13,9 @@ The lifecycle contract is intentionally small:
 
 Engine/app/bootstrap wiring does not belong in this crate.
 
+For runtime-loaded guests, the canonical public contract lives in
+`freven_guest`, not in transport-specific ABI docs.
+
 ## Stability and semver stance
 
 - Public runtime/mod contracts are treated as stable API.

--- a/crates/freven_guest/Cargo.toml
+++ b/crates/freven_guest/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "freven_guest"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+serde.workspace = true

--- a/crates/freven_guest/src/lib.rs
+++ b/crates/freven_guest/src/lib.rs
@@ -1,0 +1,109 @@
+//! Canonical public guest contract for runtime-loaded Freven mods.
+//!
+//! The crate is transport-agnostic by design. Wasm ptr/len exports, native
+//! process envelopes, and other backend-specific details live in transport
+//! crates and docs, not in the semantic contract.
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
+use serde::{Deserialize, Serialize};
+
+pub const GUEST_CONTRACT_VERSION_1: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GuestTransport {
+    WasmPtrLenV1,
+    NativePtrLenV1,
+    ExternalEnvelopeV1,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NegotiationRequest {
+    pub supported_contract_versions: Vec<u32>,
+    pub transport: GuestTransport,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NegotiationResponse {
+    pub selected_contract_version: u32,
+    pub description: GuestDescription,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GuestDescription {
+    pub guest_id: String,
+    pub lifecycle: LifecycleHooks,
+    pub action_entrypoint: bool,
+    pub actions: Vec<ActionBinding>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LifecycleHooks {
+    pub start_client: bool,
+    pub start_server: bool,
+    pub tick_client: bool,
+    pub tick_server: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActionBinding {
+    pub key: String,
+    pub binding_id: u32,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StartInput {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TickInput {
+    pub tick: u64,
+    pub dt_millis: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActionInput<'a> {
+    pub binding_id: u32,
+    pub player_id: u64,
+    pub level_id: u32,
+    pub stream_epoch: u32,
+    pub action_seq: u32,
+    pub at_input_seq: u32,
+    #[serde(borrow)]
+    pub payload: &'a [u8],
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LifecycleAck {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActionResult {
+    pub outcome: ActionOutcome,
+    pub effects: EffectBatch,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionOutcome {
+    Applied,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct EffectBatch {
+    pub world: Vec<WorldEffect>,
+}
+
+impl EffectBatch {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.world.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum WorldEffect {
+    SetBlock { pos: (i32, i32, i32), block_id: u8 },
+}

--- a/docs/EXTERNAL_MOD_IPC_v1.md
+++ b/docs/EXTERNAL_MOD_IPC_v1.md
@@ -2,6 +2,9 @@
 
 This document defines the companion-process protocol for `kind = "external"` mods.
 
+This is a legacy action-only transport protocol. The canonical public guest
+contract is `freven_guest` as documented in `GUEST_CONTRACT_v1.md`.
+
 ## Transport
 
 - Parent process spawns one OS process per external mod.

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -1,0 +1,76 @@
+# Guest Contract v1
+
+`freven_guest` is the canonical public contract for runtime-loaded Freven mods.
+
+## Scope
+
+- Semantic contract only.
+- Transport-agnostic.
+- Shared meaning across Wasm, native, and external-process backends.
+
+Transport adapters may use different wire shapes, but they must carry the same
+contract meaning defined here.
+
+## Versioning
+
+- Contract version constant: `GUEST_CONTRACT_VERSION_1`
+- Types in `freven_guest` are intentionally unversioned.
+- Future breaking contract revisions should use a new contract version and, if
+  needed, a new module path or crate revision. Do not mix `contract vN` with
+  `*V1` type names inside the same contract family.
+
+## Negotiation
+
+Host and guest negotiate before any lifecycle or action callback.
+
+- `NegotiationRequest`
+  - `supported_contract_versions: Vec<u32>`
+  - `transport: GuestTransport`
+- `NegotiationResponse`
+  - `selected_contract_version: u32`
+  - `description: GuestDescription`
+
+## Guest description
+
+`GuestDescription` declares:
+
+- `guest_id`
+- `lifecycle: LifecycleHooks`
+- `action_entrypoint`
+- `actions: Vec<ActionBinding>`
+
+`LifecycleHooks` currently exposes:
+
+- `start_client`
+- `start_server`
+- `tick_client`
+- `tick_server`
+
+`on_start_common` is intentionally not part of the guest contract yet.
+
+## Action path
+
+- Host sends `ActionInput`
+- Guest returns `ActionResult`
+- `ActionResult.outcome` is `applied` or `rejected`
+- `ActionResult.effects` currently supports world effects through `WorldEffect`
+
+## Lifecycle path
+
+Lifecycle calls are currently ack-only.
+
+- Host sends `StartInput` or `TickInput`
+- Guest returns `LifecycleAck`
+
+There is intentionally no lifecycle effect/output channel in contract v1.
+Lifecycle outputs are deferred until the runtime supports a real, honest
+end-to-end lifecycle output model.
+
+## Disable-on-session semantics
+
+If a guest violates the contract or faults during a runtime session:
+
+- that guest is disabled for the remainder of the runtime session
+- further action dispatches to that guest must reject
+- the host must stop routing later lifecycle callbacks to that guest for that
+  session

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -2,6 +2,9 @@
 
 This document defines the in-process native dynamic-library ABI for Freven native mods.
 
+This is a legacy action-only transport ABI. The canonical public guest contract
+is `freven_guest` as documented in `GUEST_CONTRACT_v1.md`.
+
 ## Required exports
 
 A native mod dynamic library must export these symbols:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,10 @@
 
 These docs describe the public SDK contracts; engine internals are private.
 
-Current note: the transport ABI docs below are v1 action-path contracts. They do not define the full long-term mod lifecycle on their own.
+The canonical public guest contract lives in `freven_guest`; transport ABI docs
+below describe concrete backend wire formats that must map to that contract.
 
+- [GUEST_CONTRACT_v1.md](GUEST_CONTRACT_v1.md)
 - [SDK_DISTRIBUTION.md](SDK_DISTRIBUTION.md)
 - [WASM_ABI_v1.md](WASM_ABI_v1.md)
 - [NATIVE_MOD_ABI_v1.md](NATIVE_MOD_ABI_v1.md)

--- a/docs/UNSAFE_NATIVE_MODS.md
+++ b/docs/UNSAFE_NATIVE_MODS.md
@@ -2,6 +2,9 @@
 
 Native mods (`kind = "native"`) are opt-in and disabled by default.
 
+The canonical public guest contract is `freven_guest`. Native loading remains a
+separate unsafe transport path and is not the primary guest contract surface.
+
 ## Enable
 
 Use one of:

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -2,9 +2,14 @@
 
 This document defines the Freven WASM mod ABI for WP7A.
 
+The canonical public guest contract is `freven_guest` and is documented in
+`GUEST_CONTRACT_v1.md`. This document covers the Wasm transport mapping for that
+contract.
+
 ## Scope
 
-- Supports action registration and action handling only.
+- Supports negotiation, lifecycle callbacks, and action handling over Wasm
+  ptr/len calls.
 - Host runs modules with no WASI and no host imports by default.
 - `[capabilities]` in `mod.toml` is enforced by runtime with a strict allowlist.
 
@@ -12,56 +17,74 @@ This document defines the Freven WASM mod ABI for WP7A.
 
 A module must export these symbols:
 
-- `freven_alloc(size: u32) -> u32`
-- `freven_dealloc(ptr: u32, size: u32)`
-- `freven_init() -> u64`
-- `freven_handle_action(kind: u32, ptr: u32, len: u32) -> u64`
+- `freven_guest_alloc(size: u32) -> u32`
+- `freven_guest_dealloc(ptr: u32, size: u32)`
+- `freven_guest_negotiate(ptr: u32, len: u32) -> u64`
+- `freven_guest_handle_action(ptr: u32, len: u32) -> u64` if `action_entrypoint = true`
 - linear memory export named `memory`
 
-`freven_init` and `freven_handle_action` return packed `(ptr, len)` as:
+Optional lifecycle exports:
+
+- `freven_guest_on_start_client(ptr: u32, len: u32) -> u64`
+- `freven_guest_on_start_server(ptr: u32, len: u32) -> u64`
+- `freven_guest_on_tick_client(ptr: u32, len: u32) -> u64`
+- `freven_guest_on_tick_server(ptr: u32, len: u32) -> u64`
+
+`freven_guest_negotiate`, lifecycle callbacks, and `freven_guest_handle_action`
+return packed `(ptr, len)` as:
 
 - `((ptr as u64) << 32) | (len as u64)`
 
-The host copies returned bytes from guest memory and then calls `freven_dealloc(ptr, len)`.
+The host copies returned bytes from guest memory and then calls
+`freven_guest_dealloc(ptr, len)`.
 
 ## Encoding
 
-ABI payloads are `postcard` encoded structs from `crates/freven_wasm_abi`.
+ABI payloads are `postcard` encoded values from `freven_guest`.
 
-### Manifest (`freven_init` return bytes)
+### Negotiation (`freven_guest_negotiate`)
 
-`ModManifestV1`:
+Input: `NegotiationRequest`
 
-- `abi_version: u32` (must be `1`)
-- `actions: Vec<ActionBindingV1>`
-
-`ActionBindingV1`:
-
-- `key: String` (runtime action key, example `freven.example:wasm_set_block`)
-- `kind: u32` (module-local dispatch id passed to `freven_handle_action`)
+Output: `NegotiationResponse`
 
 Host behavior:
 
-- validates `abi_version == 1`
+- validates `selected_contract_version`
+- validates `GuestDescription` against exported Wasm symbols
 - registers each `actions[].key` as runtime action kind
-- maps runtime action kind to `actions[].kind` for callback dispatch
+- maps runtime action kind to `actions[].binding_id` for callback dispatch
 
-### Action input (`freven_handle_action` input bytes)
+### Lifecycle inputs and outputs
 
-`ActionInputV1`:
+- `freven_guest_on_start_*` input: `StartInput`
+- `freven_guest_on_tick_*` input: `TickInput`
+- lifecycle output: `LifecycleAck`
 
+Lifecycle is intentionally ack-only in guest contract v1. Returning any richer
+lifecycle effect payload is not part of the contract.
+
+### Action input (`freven_guest_handle_action` input bytes)
+
+`ActionInput`:
+
+- `binding_id: u32`
 - `player_id: u64`
+- `level_id: u32`
+- `stream_epoch: u32`
+- `action_seq: u32`
 - `at_input_seq: u32`
 - `payload: &[u8]` (opaque client/server action payload)
 
-### Action result (`freven_handle_action` return bytes)
+### Action result (`freven_guest_handle_action` return bytes)
 
-`ActionResultV1`:
+`ActionResult`:
 
-- `outcome: ActionOutcomeV1` (`applied` or `rejected`)
-- `edits: Vec<WorldEditV1>`
+- `outcome: ActionOutcome` (`applied` or `rejected`)
+- `effects: EffectBatch`
 
-`WorldEditV1` is a `postcard`-encoded Rust enum.
+`WorldEffect` is a `postcard`-encoded Rust enum carried inside
+`EffectBatch.world`.
 
 ABI rule: enum variant order is ABI-significant.
 - Do NOT reorder variants.
@@ -72,7 +95,9 @@ Currently supported variants:
 
 - `SetBlock { pos: (i32, i32, i32), block_id: u8 }`
 
-Host applies `SetBlock` edits through server world-edit APIs. Any decode/trap/apply failure is treated as `Rejected`.
+Host applies `SetBlock` effects through server world-edit APIs. Any
+decode/trap/apply failure disables that guest for the runtime session and the
+action rejects.
 
 ## Capability policy (implemented in `freven_runtime_wasm`)
 
@@ -112,11 +137,11 @@ Common limits include:
 - maximum call time budget
 - maximum linear memory usage
 - maximum input payload bytes accepted from runtime to guest
-- maximum output bytes for `freven_init` manifest and `freven_handle_action` result
+- maximum output bytes for negotiation, lifecycle, and action result payloads
 
-Guest modules must return packed `(ptr, len)` ranges that are valid and within host-configured
-size limits. If a call exceeds limits (time, memory, or byte caps), host may reject/trap the call
-and runtime treats the action as rejected.
+Guest modules must return packed `(ptr, len)` ranges that are valid and within
+host-configured size limits. If a call exceeds limits or violates the contract,
+the runtime may disable that guest for the current runtime session.
 
 Time budgets may be enforced using Wasmtime epoch deadlines driven by host epoch ticking
 (implementation detail only; ABI contract is unchanged).


### PR DESCRIPTION
Add the new transport-agnostic guest contract crate and update SDK docs to define it as the canonical public contract for runtime-loaded mods.

## Summary
This PR introduces `freven_guest` as the canonical public contract for runtime-loaded Freven mods.

It adds a new transport-agnostic guest contract crate that defines negotiation, lifecycle, action input/output, and effect payload semantics without binding those meanings to a specific transport. It also updates SDK docs and repo-level guidance so the public model is centered on `freven_guest`, while existing Wasm/native/external ABI documents are repositioned as concrete transport mappings or legacy action-path docs rather than the primary semantic contract.

The goal is to freeze one honest public guest contract for mod architecture v2 and stop treating transport-specific ABI shapes as the full long-term mod model.

## Validation
List what you ran:
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo test --workspace --all-features

## freven-sdk dependency
- Does this PR change the pinned `freven-sdk` tag?
  - [ ] No
  - [x] Yes (which tag and why?)

This PR adds a new public SDK crate, `freven_guest`, and updates the public guest contract/docs around it. Downstream repos that consume the SDK will need a new pinned tag once this change is merged and released.

## Notes for reviewers
The most important thing to review is the boundary decision: `freven_guest` is intended to be the semantic contract, while transport ABI docs should now be read as mappings of that contract, not as competing top-level mod models.

It is also worth double-checking the v1 naming and versioning stance here: contract versioning is explicit through negotiation, while the Rust types in `freven_guest` intentionally avoid `*V1` suffixes inside the crate itself.