### PR TITLE
Introduce freven_guest_sdk authoring layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +43,15 @@ dependencies = [
 name = "freven_guest"
 version = "0.1.0"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "freven_guest_sdk"
+version = "0.1.0"
+dependencies = [
+ "freven_guest",
+ "postcard",
  "serde",
 ]
 
@@ -54,6 +84,18 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/freven_api",
     "crates/freven_guest",
+    "crates/freven_guest_sdk",
     "crates/freven_sdk_types",
     "crates/freven_std",
 ]
@@ -17,7 +18,9 @@ documentation = "https://github.com/frevenengine/freven-sdk/tree/main/docs"
 publish = false
 
 [workspace.dependencies]
+freven_guest = { path = "crates/freven_guest", version = "0.1.0" }
 freven_sdk_types = { path = "crates/freven_sdk_types", version = "0.1.0" }
+postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.228", features = ["derive"] }
 toml = "1.0.1"
 thiserror = "2.0.18"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The **engine source is private** and is **not** part of this repository.
 Current SDK crates:
 - `freven_api` - stable-ish SDK contracts (pre-1.0)
 - `freven_guest` - canonical transport-agnostic guest contract for runtime-loaded mods
+- `freven_guest_sdk` - high-level guest authoring SDK for the normal Wasm mod path
 - `freven_sdk_types` - pure shared SDK types
 - `freven_std` - early stdlib helpers (**unstable**; depend only if you accept breakage)
 
@@ -20,13 +21,24 @@ Use tagged git dependencies until crates.io publishing begins:
 ```toml
 [dependencies]
 freven_api = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_api" }
-freven_guest = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_guest" }
+freven_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_guest_sdk" }
 freven_sdk_types = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_sdk_types" }
+
+# Low-level guest contract / transport work only:
+# freven_guest = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_guest" }
 # Optional / unstable:
 # freven_std = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_std" }
 ```
 
 See [docs/SDK_DISTRIBUTION.md](docs/SDK_DISTRIBUTION.md) for the rollout plan and release policy.
+
+## Recommended authoring path
+
+- Start with [docs/WASM_AUTHORING.md](docs/WASM_AUTHORING.md).
+- Use `freven_guest_sdk` for normal mod authoring.
+- Treat `freven_guest` and the transport ABI docs as reference material for low-level tests, fixtures, and runtime work.
+- Prefer Wasm for the primary safe path.
+- Treat native and external transports as secondary integrations with narrower maturity/safety guarantees.
 
 ## Stability notes
 

--- a/crates/freven_guest_sdk/Cargo.toml
+++ b/crates/freven_guest_sdk/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "freven_guest_sdk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+freven_guest.workspace = true
+postcard.workspace = true
+serde.workspace = true

--- a/crates/freven_guest_sdk/README.md
+++ b/crates/freven_guest_sdk/README.md
@@ -1,0 +1,60 @@
+# freven_guest_sdk
+
+High-level guest authoring helpers for Freven runtime-loaded mods.
+
+Use this crate for the normal Wasm authoring path. It sits on top of the
+canonical `freven_guest` contract and hides the transport boilerplate:
+
+- guest alloc/dealloc exports
+- `postcard` encode/decode plumbing
+- Wasm export table wiring
+- lifecycle/action dispatch lookup
+- export-surface validation against the canonical `GuestDescription`
+
+Most mod authors should depend on `freven_guest_sdk`. Reach for
+`freven_guest` directly only when you are implementing or testing the raw guest
+contract itself.
+
+## Minimal example
+
+```rust
+use freven_guest_sdk::{ActionContext, ActionResponse};
+
+fn handle_action(ctx: ActionContext<'_>) -> ActionResponse {
+    let _ = ctx.player_id();
+    ActionResponse::applied().set_block((4, 80, 4), 1)
+}
+
+freven_guest_sdk::wasm_guest!(
+    guest_id: "freven.example.wasm",
+    lifecycle: {
+        start_server: |_| {},
+        tick_server: |tick| {
+            let _ = tick.tick;
+        },
+    },
+    actions: {
+        "freven.example:set_block" => {
+            binding_id: 1,
+            handler: handle_action,
+        },
+    },
+);
+```
+
+`wasm_guest!` is the normal public authoring path: the guest id, lifecycle
+hooks, action bindings, negotiated `GuestDescription`, and emitted Wasm export
+surface all come from that one declaration.
+
+`GuestModule` plus `export_wasm_guest!(...)` remain available for lower-level
+fixtures and ABI-focused tests when you intentionally need to wire the raw
+surface yourself.
+
+## Current boundaries
+
+- Lifecycle hooks are ack-only because contract v1 does not expose lifecycle
+  output payloads yet.
+- Guest-side persistent instance state is not modeled by the SDK today. Use
+  explicit statics only when you fully control the implications.
+- Wasm is the primary safe path. Native and external transports remain
+  secondary transport integrations with separate operational tradeoffs.

--- a/crates/freven_guest_sdk/src/lib.rs
+++ b/crates/freven_guest_sdk/src/lib.rs
@@ -1,0 +1,803 @@
+//! High-level guest authoring helpers built on top of `freven_guest`.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+pub use freven_guest::{
+    ActionBinding, ActionInput, ActionOutcome, ActionResult, EffectBatch, GUEST_CONTRACT_VERSION_1,
+    GuestDescription, GuestTransport, LifecycleAck, LifecycleHooks, NegotiationRequest,
+    NegotiationResponse, StartInput, TickInput, WorldEffect,
+};
+use serde::de::DeserializeOwned;
+
+type StartHandler = fn(&StartInput);
+type TickHandler = fn(&TickInput);
+type ActionHandler = fn(ActionContext<'_>) -> ActionResponse;
+
+pub struct GuestModule {
+    guest_id: &'static str,
+    actions: Vec<GuestAction>,
+    on_start_client: Option<StartHandler>,
+    on_start_server: Option<StartHandler>,
+    on_tick_client: Option<TickHandler>,
+    on_tick_server: Option<TickHandler>,
+}
+
+impl GuestModule {
+    #[must_use]
+    pub fn new(guest_id: &'static str) -> Self {
+        assert!(
+            !guest_id.trim().is_empty(),
+            "freven_guest_sdk guest_id must not be empty"
+        );
+        Self {
+            guest_id,
+            actions: Vec::new(),
+            on_start_client: None,
+            on_start_server: None,
+            on_tick_client: None,
+            on_tick_server: None,
+        }
+    }
+
+    #[must_use]
+    pub fn on_start_client(mut self, handler: StartHandler) -> Self {
+        self.on_start_client = Some(handler);
+        self
+    }
+
+    #[must_use]
+    pub fn on_start_server(mut self, handler: StartHandler) -> Self {
+        self.on_start_server = Some(handler);
+        self
+    }
+
+    #[must_use]
+    pub fn on_tick_client(mut self, handler: TickHandler) -> Self {
+        self.on_tick_client = Some(handler);
+        self
+    }
+
+    #[must_use]
+    pub fn on_tick_server(mut self, handler: TickHandler) -> Self {
+        self.on_tick_server = Some(handler);
+        self
+    }
+
+    #[must_use]
+    pub fn action(mut self, key: &'static str, binding_id: u32, handler: ActionHandler) -> Self {
+        assert!(
+            !key.trim().is_empty(),
+            "freven_guest_sdk action key must not be empty"
+        );
+        assert!(
+            self.actions.iter().all(|action| action.key != key),
+            "freven_guest_sdk action key '{key}' was registered more than once"
+        );
+        assert!(
+            self.actions
+                .iter()
+                .all(|action| action.binding_id != binding_id),
+            "freven_guest_sdk binding id {binding_id} was registered more than once"
+        );
+        self.actions.push(GuestAction {
+            key,
+            binding_id,
+            handler,
+        });
+        self
+    }
+
+    #[must_use]
+    pub fn guest_id(&self) -> &'static str {
+        self.guest_id
+    }
+
+    #[must_use]
+    pub fn lifecycle_hooks(&self) -> LifecycleHooks {
+        LifecycleHooks {
+            start_client: self.on_start_client.is_some(),
+            start_server: self.on_start_server.is_some(),
+            tick_client: self.on_tick_client.is_some(),
+            tick_server: self.on_tick_server.is_some(),
+        }
+    }
+
+    #[must_use]
+    pub fn description(&self) -> GuestDescription {
+        GuestDescription {
+            guest_id: self.guest_id.to_string(),
+            lifecycle: self.lifecycle_hooks(),
+            action_entrypoint: !self.actions.is_empty(),
+            actions: self
+                .actions
+                .iter()
+                .map(|action| ActionBinding {
+                    key: action.key.to_string(),
+                    binding_id: action.binding_id,
+                })
+                .collect(),
+        }
+    }
+
+    pub fn handle_start_client(&self, input: &StartInput) {
+        if let Some(handler) = self.on_start_client {
+            handler(input);
+        }
+    }
+
+    pub fn handle_start_server(&self, input: &StartInput) {
+        if let Some(handler) = self.on_start_server {
+            handler(input);
+        }
+    }
+
+    pub fn handle_tick_client(&self, input: &TickInput) {
+        if let Some(handler) = self.on_tick_client {
+            handler(input);
+        }
+    }
+
+    pub fn handle_tick_server(&self, input: &TickInput) {
+        if let Some(handler) = self.on_tick_server {
+            handler(input);
+        }
+    }
+
+    #[must_use]
+    pub fn handle_action(&self, input: ActionInput<'_>) -> ActionResult {
+        let Some(action) = self
+            .actions
+            .iter()
+            .find(|action| action.binding_id == input.binding_id)
+        else {
+            return ActionResponse::rejected().finish();
+        };
+
+        (action.handler)(ActionContext { input }).finish()
+    }
+}
+
+struct GuestAction {
+    key: &'static str,
+    binding_id: u32,
+    handler: ActionHandler,
+}
+
+pub struct ActionContext<'a> {
+    input: ActionInput<'a>,
+}
+
+impl<'a> ActionContext<'a> {
+    #[must_use]
+    pub fn input(&self) -> &ActionInput<'a> {
+        &self.input
+    }
+
+    #[must_use]
+    pub fn binding_id(&self) -> u32 {
+        self.input.binding_id
+    }
+
+    #[must_use]
+    pub fn player_id(&self) -> u64 {
+        self.input.player_id
+    }
+
+    #[must_use]
+    pub fn level_id(&self) -> u32 {
+        self.input.level_id
+    }
+
+    #[must_use]
+    pub fn stream_epoch(&self) -> u32 {
+        self.input.stream_epoch
+    }
+
+    #[must_use]
+    pub fn action_seq(&self) -> u32 {
+        self.input.action_seq
+    }
+
+    #[must_use]
+    pub fn at_input_seq(&self) -> u32 {
+        self.input.at_input_seq
+    }
+
+    #[must_use]
+    pub fn payload(&self) -> &'a [u8] {
+        self.input.payload
+    }
+
+    pub fn decode_payload<T>(&self) -> Result<T, postcard::Error>
+    where
+        T: DeserializeOwned,
+    {
+        postcard::from_bytes(self.input.payload)
+    }
+}
+
+pub struct ActionResponse {
+    outcome: ActionOutcome,
+    effects: EffectBatch,
+}
+
+impl ActionResponse {
+    #[must_use]
+    pub fn applied() -> Self {
+        Self {
+            outcome: ActionOutcome::Applied,
+            effects: EffectBatch::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn rejected() -> Self {
+        Self {
+            outcome: ActionOutcome::Rejected,
+            effects: EffectBatch::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn push_world_effect(mut self, effect: WorldEffect) -> Self {
+        self.effects.world.push(effect);
+        self
+    }
+
+    #[must_use]
+    pub fn set_block(self, pos: (i32, i32, i32), block_id: u8) -> Self {
+        self.push_world_effect(WorldEffect::SetBlock { pos, block_id })
+    }
+
+    #[must_use]
+    pub fn finish(self) -> ActionResult {
+        ActionResult {
+            outcome: self.outcome,
+            effects: self.effects,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub mod __private {
+    use super::*;
+
+    pub fn guest_alloc(size: u32) -> u32 {
+        let mut buf = Vec::<u8>::with_capacity(size as usize);
+        let ptr = buf.as_mut_ptr();
+        core::mem::forget(buf);
+        ptr as usize as u32
+    }
+
+    pub fn guest_dealloc(ptr: u32, size: u32) {
+        if ptr == 0 {
+            return;
+        }
+        unsafe {
+            let _ = Vec::from_raw_parts(ptr as usize as *mut u8, size as usize, size as usize);
+        }
+    }
+
+    pub fn guest_negotiate(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        if len > 0 {
+            let input =
+                unsafe { core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) };
+            let request: NegotiationRequest =
+                postcard::from_bytes(input).expect("valid negotiation request");
+            assert_eq!(request.transport, GuestTransport::WasmPtrLenV1);
+            assert!(
+                request
+                    .supported_contract_versions
+                    .contains(&GUEST_CONTRACT_VERSION_1)
+            );
+        }
+
+        let response = NegotiationResponse {
+            selected_contract_version: GUEST_CONTRACT_VERSION_1,
+            description: module.description(),
+        };
+        encode_to_guest(&response)
+    }
+
+    pub fn guest_start_client(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        let input = decode_default_input::<StartInput>(ptr, len);
+        module.handle_start_client(&input);
+        encode_lifecycle_ack()
+    }
+
+    pub fn guest_start_server(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        let input = decode_default_input::<StartInput>(ptr, len);
+        module.handle_start_server(&input);
+        encode_lifecycle_ack()
+    }
+
+    pub fn guest_tick_client(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        let input = decode_required_input::<TickInput>(ptr, len);
+        module.handle_tick_client(&input);
+        encode_lifecycle_ack()
+    }
+
+    pub fn guest_tick_server(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        let input = decode_required_input::<TickInput>(ptr, len);
+        module.handle_tick_server(&input);
+        encode_lifecycle_ack()
+    }
+
+    pub fn guest_handle_action(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        let input = if len == 0 {
+            ActionInput {
+                binding_id: 0,
+                player_id: 0,
+                level_id: 0,
+                stream_epoch: 0,
+                action_seq: 0,
+                at_input_seq: 0,
+                payload: &[],
+            }
+        } else {
+            let bytes =
+                unsafe { core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) };
+            postcard::from_bytes(bytes).expect("valid action input")
+        };
+
+        let result = module.handle_action(input);
+        encode_to_guest(&result)
+    }
+
+    fn decode_default_input<T>(ptr: u32, len: u32) -> T
+    where
+        T: Default + serde::de::DeserializeOwned,
+    {
+        if len == 0 {
+            return T::default();
+        }
+
+        let bytes = unsafe { core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) };
+        postcard::from_bytes(bytes).expect("valid guest input")
+    }
+
+    fn decode_required_input<T>(ptr: u32, len: u32) -> T
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        assert!(len > 0, "guest input must not be empty");
+        let bytes = unsafe { core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) };
+        postcard::from_bytes(bytes).expect("valid guest input")
+    }
+
+    fn encode_lifecycle_ack() -> u64 {
+        encode_to_guest(&LifecycleAck::default())
+    }
+
+    fn encode_to_guest<T>(value: &T) -> u64
+    where
+        T: serde::Serialize,
+    {
+        let bytes = postcard::to_allocvec(value).expect("guest encoding must succeed");
+        let len = u32::try_from(bytes.len()).expect("guest buffer length must fit u32");
+        let ptr = guest_alloc(len);
+        unsafe {
+            core::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr as usize as *mut u8, bytes.len());
+        }
+        (u64::from(ptr) << 32) | u64::from(len)
+    }
+
+    pub fn assert_export_surface(
+        module: &GuestModule,
+        lifecycle: LifecycleHooks,
+        action_entrypoint: bool,
+    ) {
+        let description = module.description();
+        assert_eq!(
+            description.lifecycle, lifecycle,
+            "freven_guest_sdk export lifecycle does not match GuestModule::description()",
+        );
+        assert_eq!(
+            description.action_entrypoint, action_entrypoint,
+            "freven_guest_sdk action export does not match GuestModule::description()",
+        );
+    }
+}
+
+/// Lower-level Wasm export wiring for cases where you intentionally manage a
+/// `GuestModule` factory and export surface separately.
+#[macro_export]
+macro_rules! export_wasm_guest {
+    (
+        factory: $factory:path
+        $(, lifecycle: [$($lifecycle:ident),* $(,)?])?
+        $(, actions: $actions:tt)?
+        $(,)?
+    ) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_alloc(size: u32) -> u32 {
+            $crate::__private::guest_alloc(size)
+        }
+
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_dealloc(ptr: u32, size: u32) {
+            $crate::__private::guest_dealloc(ptr, size)
+        }
+
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_negotiate(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::assert_export_surface(
+                &module,
+                $crate::export_wasm_guest!(@lifecycle_struct $($($lifecycle),*)?),
+                $crate::export_wasm_guest!(@actions_bool $($actions)?),
+            );
+            $crate::__private::guest_negotiate(&module, ptr, len)
+        }
+
+        $crate::export_wasm_guest!(@maybe_export $factory, start_client, $($($lifecycle),*)?);
+        $crate::export_wasm_guest!(@maybe_export $factory, start_server, $($($lifecycle),*)?);
+        $crate::export_wasm_guest!(@maybe_export $factory, tick_client, $($($lifecycle),*)?);
+        $crate::export_wasm_guest!(@maybe_export $factory, tick_server, $($($lifecycle),*)?);
+        $crate::export_wasm_guest!(@maybe_export_action $factory, $($actions)?);
+    };
+
+    (@lifecycle_struct $($hook:ident),*) => {{
+        let mut hooks = $crate::LifecycleHooks::default();
+        $(hooks.$hook = true;)*
+        hooks
+    }};
+
+    (@actions_bool true) => {
+        true
+    };
+    (@actions_bool false) => {
+        false
+    };
+    (@actions_bool) => {
+        false
+    };
+
+    (@maybe_export $factory:path, start_client, start_client $(, $rest:ident)*) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_start_client(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::guest_start_client(&module, ptr, len)
+        }
+    };
+    (@maybe_export $factory:path, start_client, $_head:ident $(, $rest:ident)*) => {
+        $crate::export_wasm_guest!(@maybe_export $factory, start_client $(, $rest)*);
+    };
+    (@maybe_export $factory:path, start_client,) => {};
+    (@maybe_export $factory:path, start_client) => {};
+
+    (@maybe_export $factory:path, start_server, start_server $(, $rest:ident)*) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_start_server(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::guest_start_server(&module, ptr, len)
+        }
+    };
+    (@maybe_export $factory:path, start_server, $_head:ident $(, $rest:ident)*) => {
+        $crate::export_wasm_guest!(@maybe_export $factory, start_server $(, $rest)*);
+    };
+    (@maybe_export $factory:path, start_server,) => {};
+    (@maybe_export $factory:path, start_server) => {};
+
+    (@maybe_export $factory:path, tick_client, tick_client $(, $rest:ident)*) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_tick_client(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::guest_tick_client(&module, ptr, len)
+        }
+    };
+    (@maybe_export $factory:path, tick_client, $_head:ident $(, $rest:ident)*) => {
+        $crate::export_wasm_guest!(@maybe_export $factory, tick_client $(, $rest)*);
+    };
+    (@maybe_export $factory:path, tick_client,) => {};
+    (@maybe_export $factory:path, tick_client) => {};
+
+    (@maybe_export $factory:path, tick_server, tick_server $(, $rest:ident)*) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_tick_server(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::guest_tick_server(&module, ptr, len)
+        }
+    };
+    (@maybe_export $factory:path, tick_server, $_head:ident $(, $rest:ident)*) => {
+        $crate::export_wasm_guest!(@maybe_export $factory, tick_server $(, $rest)*);
+    };
+    (@maybe_export $factory:path, tick_server,) => {};
+    (@maybe_export $factory:path, tick_server) => {};
+
+    (@maybe_export_action $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_handle_action(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::guest_handle_action(&module, ptr, len)
+        }
+    };
+    (@maybe_export_action $factory:path, false) => {};
+    (@maybe_export_action $factory:path) => {};
+}
+
+/// Defines the canonical guest description and the Wasm export surface from one
+/// declarative source of truth.
+#[macro_export]
+macro_rules! wasm_guest {
+    (
+        guest_id: $guest_id:expr
+        $(, lifecycle: { $($lifecycle:ident : $lifecycle_handler:expr),* $(,)? })?
+        $(, actions: {
+            $(
+                $action_key:expr => {
+                    binding_id: $binding_id:expr,
+                    handler: $action_handler:expr
+                    $(,)?
+                }
+            ),* $(,)?
+        })?
+        $(,)?
+    ) => {
+        #[doc(hidden)]
+        fn __freven_guest_sdk_module() -> $crate::GuestModule {
+            $crate::wasm_guest!(
+                @module
+                guest_id: $guest_id
+                $(, lifecycle: { $($lifecycle : $lifecycle_handler),* })?
+                $(, actions: {
+                    $(
+                        $action_key => {
+                            binding_id: $binding_id,
+                            handler: $action_handler,
+                        }
+                    ),*
+                })?
+            )
+        }
+
+        $crate::wasm_guest!(
+            @export
+            factory: __freven_guest_sdk_module
+            $(, lifecycle: [$($lifecycle),*])?
+            $(, actions: [$($action_key),*])?
+        );
+    };
+
+    (
+        @module
+        guest_id: $guest_id:expr
+        $(, lifecycle: { $($lifecycle:ident : $lifecycle_handler:expr),* $(,)? })?
+        $(, actions: {
+            $(
+                $action_key:expr => {
+                    binding_id: $binding_id:expr,
+                    handler: $action_handler:expr
+                    $(,)?
+                }
+            ),* $(,)?
+        })?
+        $(,)?
+    ) => {{
+        let module = $crate::GuestModule::new($guest_id);
+        $(
+            $(
+                let module = $crate::wasm_guest!(
+                    @register_lifecycle
+                    module,
+                    $lifecycle,
+                    $lifecycle_handler
+                );
+            )*
+        )?
+        $(
+            $(
+                let module = module.action($action_key, $binding_id, $action_handler);
+            )*
+        )?
+        module
+    }};
+
+    (@register_lifecycle $module:ident, start_client, $handler:expr) => {
+        $module.on_start_client($handler)
+    };
+    (@register_lifecycle $module:ident, start_server, $handler:expr) => {
+        $module.on_start_server($handler)
+    };
+    (@register_lifecycle $module:ident, tick_client, $handler:expr) => {
+        $module.on_tick_client($handler)
+    };
+    (@register_lifecycle $module:ident, tick_server, $handler:expr) => {
+        $module.on_tick_server($handler)
+    };
+
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+        );
+    };
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, actions: []) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+        );
+    };
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, actions: [$first:expr $(, $rest:expr)*]) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+            , actions: true
+        );
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn module() -> GuestModule {
+        GuestModule::new("freven.test.guest")
+            .on_start_server(|_| {})
+            .on_tick_server(|_| {})
+            .action("freven.test:place_block", 7, |_| {
+                ActionResponse::applied().set_block((1, 2, 3), 9)
+            })
+    }
+
+    #[test]
+    fn description_reflects_registered_lifecycle_and_actions() {
+        let description = module().description();
+        assert_eq!(description.guest_id, "freven.test.guest");
+        assert!(description.lifecycle.start_server);
+        assert!(description.lifecycle.tick_server);
+        assert!(!description.lifecycle.start_client);
+        assert!(description.action_entrypoint);
+        assert_eq!(description.actions.len(), 1);
+        assert_eq!(description.actions[0].binding_id, 7);
+        assert_eq!(description.actions[0].key, "freven.test:place_block");
+    }
+
+    #[test]
+    fn missing_binding_rejects_without_effects() {
+        let result = module().handle_action(ActionInput {
+            binding_id: 99,
+            player_id: 1,
+            level_id: 2,
+            stream_epoch: 3,
+            action_seq: 4,
+            at_input_seq: 5,
+            payload: &[],
+        });
+
+        assert_eq!(result.outcome, ActionOutcome::Rejected);
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "guest_id must not be empty")]
+    fn empty_guest_id_is_rejected() {
+        let _ = GuestModule::new("  ");
+    }
+
+    #[test]
+    #[should_panic(expected = "action key must not be empty")]
+    fn empty_action_key_is_rejected() {
+        let _ =
+            GuestModule::new("freven.test.guest").action(" ", 1, |_| ActionResponse::rejected());
+    }
+
+    #[test]
+    #[should_panic(expected = "registered more than once")]
+    fn duplicate_action_key_is_rejected() {
+        let _ = GuestModule::new("freven.test.guest")
+            .action("freven.test:dup", 1, |_| ActionResponse::rejected())
+            .action("freven.test:dup", 2, |_| ActionResponse::rejected());
+    }
+
+    #[test]
+    #[should_panic(expected = "binding id 1 was registered more than once")]
+    fn duplicate_binding_id_is_rejected() {
+        let _ = GuestModule::new("freven.test.guest")
+            .action("freven.test:first", 1, |_| ActionResponse::rejected())
+            .action("freven.test:second", 1, |_| ActionResponse::rejected());
+    }
+
+    #[test]
+    fn export_surface_assertion_matches_description() {
+        let module = module();
+        __private::assert_export_surface(
+            &module,
+            LifecycleHooks {
+                start_server: true,
+                tick_server: true,
+                ..Default::default()
+            },
+            true,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "export lifecycle does not match")]
+    fn export_surface_assertion_rejects_lifecycle_mismatch() {
+        let module = module();
+        __private::assert_export_surface(&module, LifecycleHooks::default(), true);
+    }
+
+    #[test]
+    #[should_panic(expected = "action export does not match")]
+    fn export_surface_assertion_rejects_action_mismatch() {
+        let module = module();
+        __private::assert_export_surface(
+            &module,
+            LifecycleHooks {
+                start_server: true,
+                tick_server: true,
+                ..Default::default()
+            },
+            false,
+        );
+    }
+
+    fn test_start_server(_: &StartInput) {}
+
+    fn test_tick_server(_: &TickInput) {}
+
+    fn test_handle_action(_: ActionContext<'_>) -> ActionResponse {
+        ActionResponse::applied()
+    }
+
+    #[test]
+    fn wasm_guest_macro_module_description_matches_declared_surface() {
+        let module = crate::wasm_guest!(
+            @module
+            guest_id: "freven.test.single_source",
+            lifecycle: {
+                start_server: test_start_server,
+                tick_server: test_tick_server,
+            },
+            actions: {
+                "freven.test:macro_action" => {
+                    binding_id: 11,
+                    handler: test_handle_action,
+                },
+            },
+        );
+
+        assert_eq!(module.guest_id(), "freven.test.single_source");
+        assert_eq!(
+            module.lifecycle_hooks(),
+            LifecycleHooks {
+                start_server: true,
+                tick_server: true,
+                ..Default::default()
+            }
+        );
+
+        let description = module.description();
+        assert!(description.action_entrypoint);
+        assert_eq!(description.actions.len(), 1);
+        assert_eq!(description.actions[0].key, "freven.test:macro_action");
+        assert_eq!(description.actions[0].binding_id, 11);
+    }
+
+    #[test]
+    fn wasm_guest_macro_supports_guests_without_actions() {
+        let module = crate::wasm_guest!(
+            @module
+            guest_id: "freven.test.lifecycle_only",
+            lifecycle: {
+                start_server: test_start_server,
+            },
+            actions: {},
+        );
+
+        let description = module.description();
+        assert!(!description.action_entrypoint);
+        assert!(description.actions.is_empty());
+        assert_eq!(
+            description.lifecycle,
+            LifecycleHooks {
+                start_server: true,
+                ..Default::default()
+            }
+        );
+    }
+}

--- a/docs/EXTERNAL_MOD_IPC_v1.md
+++ b/docs/EXTERNAL_MOD_IPC_v1.md
@@ -5,6 +5,10 @@ This document defines the companion-process protocol for `kind = "external"` mod
 This is a legacy action-only transport protocol. The canonical public guest
 contract is `freven_guest` as documented in `GUEST_CONTRACT_v1.md`.
 
+This is a secondary transport integration, not the default authoring story.
+Prefer Wasm with `freven_guest_sdk` unless you specifically need a companion
+process boundary.
+
 ## Transport
 
 - Parent process spawns one OS process per external mod.

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -2,6 +2,10 @@
 
 `freven_guest` is the canonical public contract for runtime-loaded Freven mods.
 
+Most mod authors should consume this contract through `freven_guest_sdk`.
+Writing directly against `freven_guest` is mainly for low-level transport work,
+fixtures, and runtime validation.
+
 ## Scope
 
 - Semantic contract only.

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -5,6 +5,10 @@ This document defines the in-process native dynamic-library ABI for Freven nativ
 This is a legacy action-only transport ABI. The canonical public guest contract
 is `freven_guest` as documented in `GUEST_CONTRACT_v1.md`.
 
+This is not the recommended public authoring path. Prefer Wasm with
+`freven_guest_sdk` unless you are intentionally doing low-level runtime work on
+trusted local code.
+
 ## Required exports
 
 A native mod dynamic library must export these symbols:

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ These docs describe the public SDK contracts; engine internals are private.
 The canonical public guest contract lives in `freven_guest`; transport ABI docs
 below describe concrete backend wire formats that must map to that contract.
 
+- [WASM_AUTHORING.md](WASM_AUTHORING.md)
 - [GUEST_CONTRACT_v1.md](GUEST_CONTRACT_v1.md)
 - [SDK_DISTRIBUTION.md](SDK_DISTRIBUTION.md)
 - [WASM_ABI_v1.md](WASM_ABI_v1.md)

--- a/docs/SDK_DISTRIBUTION.md
+++ b/docs/SDK_DISTRIBUTION.md
@@ -6,6 +6,8 @@ We follow a **GitHub-first** distribution model for the public Freven SDK.
 
 This repository (`frevenengine/freven-sdk`) is public-readable and contains:
 - `freven_api`
+- `freven_guest`
+- `freven_guest_sdk`
 - `freven_sdk_types`
 - `freven_std` (**unstable**; depend only if you accept breakage)
 
@@ -27,6 +29,7 @@ Later (planned):
 ```toml
 [dependencies]
 freven_api = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_api" }
+freven_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_guest_sdk" }
 freven_sdk_types = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_sdk_types" }
 # Optional / unstable:
 # freven_std = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_std" }

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -6,6 +6,10 @@ The canonical public guest contract is `freven_guest` and is documented in
 `GUEST_CONTRACT_v1.md`. This document covers the Wasm transport mapping for that
 contract.
 
+For normal mod authoring, use `freven_guest_sdk` and the guide in
+`WASM_AUTHORING.md`. This document is transport reference material, not the
+recommended getting-started path.
+
 ## Scope
 
 - Supports negotiation, lifecycle callbacks, and action handling over Wasm

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -1,0 +1,123 @@
+# Wasm Authoring
+
+This is the recommended public path for Freven runtime-loaded mods.
+
+Most mod authors should write against `freven_guest_sdk`, not hand-roll the raw
+Wasm ABI exports.
+
+## Why this is the default path
+
+- Wasm is the primary safe guest transport.
+- `freven_guest_sdk` keeps the canonical `freven_guest` lifecycle and action
+  model visible while hiding export-table, allocation, and `postcard` plumbing.
+- Raw ABI work is still available for fixtures and runtime validation, but it is
+  not the normal getting-started experience.
+
+## Canonical lifecycle in guest contract v1
+
+The canonical guest lifecycle today is:
+
+- negotiation
+- `on_start_client`
+- `on_start_server`
+- `on_tick_client`
+- `on_tick_server`
+- action handling through one action entrypoint plus declared bindings
+
+Current contract limits:
+
+- lifecycle hooks are ack-only in guest contract v1
+- lifecycle callbacks do not return effect batches yet
+- `on_start_common` is not part of the runtime-loaded guest contract yet
+
+Those boundaries are intentional. The SDK does not pretend lifecycle output or
+cross-transport parity exists when it does not.
+
+## Minimal authoring example
+
+```rust
+use freven_guest_sdk::{ActionContext, ActionResponse};
+
+const PLACE_BLOCK: u32 = 1;
+
+fn handle_action(ctx: ActionContext<'_>) -> ActionResponse {
+    let _ = ctx.player_id();
+    ActionResponse::applied().set_block((4, 80, 4), 1)
+}
+
+freven_guest_sdk::wasm_guest!(
+    guest_id: "freven.example.wasm",
+    lifecycle: {
+        start_server: |_| {},
+        tick_server: |tick| {
+            let _ = tick.tick;
+        },
+    },
+    actions: {
+        "freven.example:set_block" => {
+            binding_id: PLACE_BLOCK,
+            handler: handle_action,
+        },
+    },
+);
+```
+
+What the SDK hides:
+
+- `freven_guest_alloc` / `freven_guest_dealloc`
+- negotiation/lifecycle/action export implementation details
+- `postcard` encode/decode of contract payloads
+- packed `(ptr, len)` return wiring
+- action binding dispatch by `binding_id`
+
+What stays explicit:
+
+- guest id
+- declared lifecycle hooks
+- declared action bindings
+- exported Wasm capability surface generated from that same declaration
+- canonical action result semantics and world effects
+
+`wasm_guest!` is intentionally declarative rather than magical. The lifecycle
+hooks and action bindings you write are the same data used to build the
+canonical `GuestDescription` and to emit the Wasm export table, so the two
+surfaces cannot drift in normal authoring.
+
+`GuestModule` plus `export_wasm_guest!(...)` still exist as a lower-level escape
+hatch for raw ABI fixtures, runtime validation, or unusual tests, but they are
+not the recommended public authoring path.
+
+## Payload ergonomics
+
+`ActionContext` exposes the canonical input fields directly:
+
+- `binding_id()`
+- `player_id()`
+- `level_id()`
+- `stream_epoch()`
+- `action_seq()`
+- `at_input_seq()`
+- `payload()`
+- `decode_payload::<T>()`
+
+Use `ActionResponse::applied()` or `ActionResponse::rejected()` to surface the
+canonical outcome, then attach effects such as `.set_block(...)`.
+
+## Transport guidance
+
+Prefer these paths in this order:
+
+1. Wasm via `freven_guest_sdk`
+2. External process integration when you explicitly need process isolation
+3. Native only for trusted local code and engine/runtime development
+
+Native and external paths are secondary today. They remain important for
+specific cases, but they should not be presented as equivalent onboarding paths
+or as safer alternatives to Wasm.
+
+## Reference docs
+
+- Canonical contract: [GUEST_CONTRACT_v1.md](GUEST_CONTRACT_v1.md)
+- Wasm transport reference: [WASM_ABI_v1.md](WASM_ABI_v1.md)
+- Native transport reference: [NATIVE_MOD_ABI_v1.md](NATIVE_MOD_ABI_v1.md)
+- External transport reference: [EXTERNAL_MOD_IPC_v1.md](EXTERNAL_MOD_IPC_v1.md)


### PR DESCRIPTION
Add the high-level guest authoring SDK for the normal Wasm mod path and update public docs to make it the recommended entry point over raw transport ABI work.

## Summary
This PR introduces `freven_guest_sdk` as the recommended public authoring layer for runtime-loaded Wasm mods.

It adds a new high-level SDK crate on top of `freven_guest` that hides the low-level Wasm guest boilerplate, including export wiring, allocation/deallocation, `postcard` encode/decode plumbing, lifecycle dispatch, and action binding lookup. It also adds the new Wasm authoring guide and updates repo/docs language so the public story is clear: most mod authors should start with `freven_guest_sdk`, while `freven_guest` and the raw transport ABI docs remain lower-level reference material for runtime work, fixtures, and validation.

The goal is to make the normal mod authoring path explicit, ergonomic, and aligned with the mod architecture v2 contract, instead of treating raw ABI-level work as the default entry point.

## Validation
List what you ran:
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo test --workspace --all-features

## freven-sdk dependency
- Does this PR change the pinned `freven-sdk` tag?
  - [ ] No
  - [x] Yes (which tag and why?)

This PR adds a new public SDK crate, `freven_guest_sdk`, and updates the recommended public authoring path around it. Downstream repos that consume the SDK will need a new pinned tag once this change is merged and released.

## Notes for reviewers
The main thing to review is the boundary split between `freven_guest` and `freven_guest_sdk`: `freven_guest` should remain the canonical low-level guest contract, while `freven_guest_sdk` should be the normal Wasm authoring surface built on top of it.

It is also worth double-checking the macro/export behavior and the "single source of truth" claim in the docs: the declared guest description, lifecycle/action metadata, and emitted Wasm export surface should stay aligned and not drift.