### PR TITLE
Update guest transport reference docs

### DIFF
--- a/docs/EXTERNAL_MOD_IPC_v1.md
+++ b/docs/EXTERNAL_MOD_IPC_v1.md
@@ -1,9 +1,11 @@
 # External Mod IPC v1
 
-This document defines the companion-process protocol for `kind = "external"` mods.
+This document defines the companion-process protocol for `kind = "external"`
+mods.
 
-This is a legacy action-only transport protocol. The canonical public guest
-contract is `freven_guest` as documented in `GUEST_CONTRACT_v1.md`.
+The canonical public guest contract is `freven_guest` as documented in
+`GUEST_CONTRACT_v1.md`. External is a secondary transport that carries the same
+guest negotiation and action semantics over a JSON envelope.
 
 This is a secondary transport integration, not the default authoring story.
 Prefer Wasm with `freven_guest_sdk` unless you specifically need a companion
@@ -23,14 +25,18 @@ process boundary.
 - `handshake`
   - payload: `host_version: u32`
   - required first call after spawn
-- `init_manifest`
-  - returns the mod manifest/action bindings
+- `negotiate`
+  - payload: `request: NegotiationRequest`
+- `start_client`
+  - payload: `input: StartInput`
+- `start_server`
+  - payload: `input: StartInput`
+- `tick_client`
+  - payload: `input: TickInput`
+- `tick_server`
+  - payload: `input: TickInput`
 - `handle_action`
-  - payload:
-    - `kind: u32` (mod-local action id from manifest)
-    - `player_id: u64`
-    - `at_input_seq: u32`
-    - `payload: Vec<u8>`
+  - payload: `input: ActionInput`
 - `shutdown`
   - best-effort clean shutdown request sent by host before process kill fallback
 
@@ -38,18 +44,33 @@ process boundary.
 
 - `handshake`
   - payload: `protocol_version: u32`
-- `init_manifest`
-  - payload: `manifest: ModManifestV1`
+- `negotiate`
+  - payload: `response: NegotiationResponse`
+- `lifecycle`
+  - payload: `ack: LifecycleAck`
 - `handle_action`
-  - payload: `result: ActionResultV1`
+  - payload: `result: ActionResult`
 - `error`
   - payload: `message: String`
 
 ## Behavioral rules
 
-- Host enforces per-call timeout for handshake/init/action IPC.
+- Host enforces per-call timeout for handshake, negotiation, steady-state
+  lifecycle calls, and action IPC.
+- Negotiation must select `GUEST_CONTRACT_VERSION_1` and return a
+  `guest_id` that matches the resolved mod id.
+- Negotiated lifecycle declarations must be side-compatible with the runtime.
+- External transport supports the full `freven_guest` surface; if the guest
+  declares a lifecycle hook, the companion process must answer the
+  corresponding request with a `lifecycle` response carrying `LifecycleAck`.
 - If a companion process exits/crashes, disconnects, violates protocol, or times out:
   - that mod is disabled for the current runtime session
+  - later lifecycle callbacks stop
   - action calls for that mod return `ActionOutcome::Rejected`
   - host kills/waits child if still alive
-- External mods are loaded only when explicit policy is enabled (`allow_external_mods`).
+- If a valid `ActionResult` cannot be completed because host-side world-effect
+  application fails, that still counts as a guest session fault:
+  - the mod is disabled for the current runtime session
+  - follow-up lifecycle/action calls are rejected
+  - host kills/waits the companion child
+- External mods are loaded only when explicit policy is enabled (for example `--allow-external-mods` or `FREVEN_ALLOW_EXTERNAL_MODS=1`).

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -78,3 +78,6 @@ If a guest violates the contract or faults during a runtime session:
 - further action dispatches to that guest must reject
 - the host must stop routing later lifecycle callbacks to that guest for that
   session
+
+For action callbacks, "faults" include host-side failure to apply the guest's
+declared world effects after the `ActionResult` is decoded and validated.

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -1,9 +1,11 @@
 # Native Mod ABI v1
 
-This document defines the in-process native dynamic-library ABI for Freven native mods.
+This document defines the in-process native dynamic-library transport ABI for
+Freven native mods.
 
-This is a legacy action-only transport ABI. The canonical public guest contract
-is `freven_guest` as documented in `GUEST_CONTRACT_v1.md`.
+The canonical public guest contract is `freven_guest` as documented in
+`GUEST_CONTRACT_v1.md`. Native is a secondary unsafe transport that carries the
+same guest negotiation and action semantics over an in-process ptr/len ABI.
 
 This is not the recommended public authoring path. Prefer Wasm with
 `freven_guest_sdk` unless you are intentionally doing low-level runtime work on
@@ -13,14 +15,24 @@ trusted local code.
 
 A native mod dynamic library must export these symbols:
 
-- `freven_alloc(size: u32) -> u32`
-- `freven_dealloc(ptr: u32, len: u32)`
-- `freven_init() -> u64`
-- `freven_handle_action(kind: u32, payload_ptr: u32, payload_len: u32) -> u64`
+- `freven_guest_alloc(size: u32) -> u32`
+- `freven_guest_dealloc(ptr: u32, len: u32)`
+- `freven_guest_negotiate(payload_ptr: u32, payload_len: u32) -> u64`
+- `freven_guest_handle_action(payload_ptr: u32, payload_len: u32) -> u64` when
+  `action_entrypoint = true`
+- `freven_guest_on_start_client(payload_ptr: u32, payload_len: u32) -> u64`
+  when `lifecycle.start_client = true`
+- `freven_guest_on_start_server(payload_ptr: u32, payload_len: u32) -> u64`
+  when `lifecycle.start_server = true`
+- `freven_guest_on_tick_client(payload_ptr: u32, payload_len: u32) -> u64`
+  when `lifecycle.tick_client = true`
+- `freven_guest_on_tick_server(payload_ptr: u32, payload_len: u32) -> u64`
+  when `lifecycle.tick_server = true`
 
 ## Packed pointer/len format
 
-`freven_init` and `freven_handle_action` return a packed `(ptr,len)` value:
+`freven_guest_negotiate` and `freven_guest_handle_action` return a packed
+`(ptr,len)` value:
 
 - `((ptr as u64) << 32) | (len as u64)`
 
@@ -30,32 +42,38 @@ Host decodes:
 - `len = packed as u32`
 
 `ptr/len` refer to process address space memory owned by the native mod.
-Host copies bytes directly and then calls `freven_dealloc(ptr, len)`.
+Host copies bytes directly and then calls `freven_guest_dealloc(ptr, len)`.
 
 ## Encoding
 
-Returned bytes are postcard-encoded Rust ABI types from `crates/freven_wasm_abi`:
+Returned bytes are postcard-encoded `freven_guest` contract types:
 
-- `freven_init` -> `ModManifestV1`
-- `freven_handle_action` -> `ActionResultV1`
+- `freven_guest_negotiate` takes `NegotiationRequest` and returns `NegotiationResponse`
+- `freven_guest_handle_action` takes `ActionInput` and returns `ActionResult`
+- lifecycle exports take `StartInput` or `TickInput` and return `LifecycleAck`
 
-Action input bytes passed to `freven_handle_action` are postcard-encoded `ActionInputV1`.
-
-`ActionInputV1` carries `player_id` and `at_input_seq`; these fields inside the postcard payload are
-the single source of truth for action context.
+`ActionInput` carries `binding_id`, `player_id`, `level_id`, `stream_epoch`,
+`action_seq`, `at_input_seq`, and opaque payload bytes. Those fields inside the
+postcard payload are the single source of truth for action context.
 
 ## Runtime behavior
 
 Runtime validates and enforces:
 
-- `manifest.abi_version == 1`
+- negotiation selects `GUEST_CONTRACT_VERSION_1`
+- `guest_id` matches the resolved mod id
 - non-empty action keys
-- no duplicate action keys within a mod manifest
-- no duplicate host `kind` values within a mod manifest
-- max byte caps for manifest/result/input payload before copying
+- no duplicate action keys within one guest description
+- no duplicate `binding_id` values within one guest description
+- max byte caps for negotiation/result/input payload before copying
+- declared action/lifecycle surface exactly matches the exported symbol surface
+- side-incompatible lifecycle declarations are rejected during attach
 
-On decode/validation/ABI errors, attach fails.
-On action-call failures, runtime treats the action as rejected.
+On decode/validation/contract errors, attach fails.
+On lifecycle or action-call faults, runtime disables that guest mod for the
+current runtime session and later lifecycle/action calls reject. That includes
+host-side failure to apply guest-declared world effects after a valid
+`ActionResult` returns.
 
 ## Safety model
 

--- a/docs/UNSAFE_NATIVE_MODS.md
+++ b/docs/UNSAFE_NATIVE_MODS.md
@@ -39,15 +39,24 @@ Absolute paths, root/prefix components, and parent traversal are rejected during
 
 Native mods use the unified ABI surface shared with WASM/runtime contracts:
 
-- `freven_alloc(size: u32) -> u32`
-- `freven_dealloc(ptr: u32, len: u32)`
-- `freven_init() -> u64`
-- `freven_handle_action(kind: u32, payload_ptr: u32, payload_len: u32) -> u64`
+- `freven_guest_alloc(size: u32) -> u32`
+- `freven_guest_dealloc(ptr: u32, len: u32)`
+- `freven_guest_negotiate(payload_ptr: u32, payload_len: u32) -> u64`
+- `freven_guest_handle_action(payload_ptr: u32, payload_len: u32) -> u64`
+- optional lifecycle exports when declared in `GuestDescription`:
+  - `freven_guest_on_start_client`
+  - `freven_guest_on_start_server`
+  - `freven_guest_on_tick_client`
+  - `freven_guest_on_tick_server`
 
-`freven_init` returns postcard bytes for `ModManifestV1` packed as `(ptr,len)`.
-`freven_handle_action` returns postcard bytes for `ActionResultV1` packed as `(ptr,len)`.
-Action input bytes passed to `freven_handle_action` are postcard `ActionInputV1`, which is the
-only authority for `player_id` and `at_input_seq`.
+`freven_guest_negotiate` returns postcard bytes for `NegotiationResponse`
+packed as `(ptr,len)`.
+`freven_guest_handle_action` returns postcard bytes for `ActionResult` packed as
+`(ptr,len)`.
+Lifecycle exports return postcard bytes for `LifecycleAck` packed as `(ptr,len)`.
+Action input bytes passed to `freven_guest_handle_action` are postcard
+`ActionInput`, which is the only authority for action binding and runtime
+action context.
 
 Packed format matches WASM ABI v1 exactly:
 

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -100,8 +100,8 @@ Currently supported variants:
 - `SetBlock { pos: (i32, i32, i32), block_id: u8 }`
 
 Host applies `SetBlock` effects through server world-edit APIs. Any
-decode/trap/apply failure disables that guest for the runtime session and the
-action rejects.
+decode/trap/validation/apply failure disables that guest for the runtime
+session and the action rejects.
 
 ## Capability policy (implemented in `freven_runtime_wasm`)
 
@@ -117,10 +117,10 @@ Current host policy maxima/defaults:
 
 - `max_call_millis`: `25`
 - `max_linear_memory_bytes`: `4 MiB`
-- `max_manifest_bytes`: `64 KiB`
+- `max_negotiation_bytes`: `64 KiB`
 - `max_result_bytes`: `256 KiB`
 - `max_input_payload_bytes`: `64 KiB`
-- `max_edits` per action result: `128`
+- `max_world_effects` per action result: `128`
 
 Capabilities may tighten selected limits (`max_call_millis`, `max_linear_memory_bytes`) but cannot raise limits above policy maxima.
 


### PR DESCRIPTION
Document native and external as secondary transports for the canonical freven_guest contract, including negotiation, lifecycle calls, and disable-for-session fault behavior.

## Summary
This PR updates the public transport reference docs to match the current guest contract model more honestly.

It rewrites the native and external transport documentation around `freven_guest` as the canonical public contract, rather than treating those transport docs as standalone top-level mod models. The updated docs now describe negotiation, lifecycle callback transport, action handling, and disable-for-session fault semantics, and they make the intended positioning explicit: native and external remain secondary transport integrations, while Wasm with `freven_guest_sdk` is the recommended public authoring path.

The goal is to keep the SDK docs aligned with the mod architecture v2 guest runtime work and to make the transport hierarchy and fault model clear for reviewers and downstream users.

## Validation
List what you ran:
- [ ] cargo fmt --all -- --check
- [ ] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [ ] cargo test --workspace --all-features

## freven-sdk dependency
- Does this PR change the pinned `freven-sdk` tag?
  - [x] No
  - [ ] Yes (which tag and why?)

## Notes for reviewers
This is a docs-only update. The main thing to review is semantic consistency: the transport docs should describe native and external as mappings of the canonical `freven_guest` contract, not as competing public contract surfaces.

It is also worth double-checking that the documented fault behavior matches the intended public stance: transport, decode, protocol, lifecycle, and host-side world-apply failures are all described as session-disabling guest faults.