### PR TITLE
Align transport docs with execution model

### DIFF
--- a/docs/EXTERNAL_MOD_IPC_v1.md
+++ b/docs/EXTERNAL_MOD_IPC_v1.md
@@ -1,7 +1,7 @@
 # External Mod IPC v1
 
-This document defines the companion-process protocol for `kind = "external"`
-mods.
+This document defines the companion-process protocol for mods with
+`execution = "external_guest"`.
 
 The canonical public guest contract is `freven_guest` as documented in
 `GUEST_CONTRACT_v1.md`. External is a secondary transport that carries the same
@@ -59,7 +59,8 @@ process boundary.
   lifecycle calls, and action IPC.
 - Negotiation must select `GUEST_CONTRACT_VERSION_1` and return a
   `guest_id` that matches the resolved mod id.
-- Negotiated lifecycle declarations must be side-compatible with the runtime.
+- Negotiated lifecycle declarations may include both client and server hooks.
+  The runtime hosts the active side as a subset for the current session.
 - External transport supports the full `freven_guest` surface; if the guest
   declares a lifecycle hook, the companion process must answer the
   corresponding request with a `lifecycle` response carrying `LifecycleAck`.

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -84,4 +84,4 @@ Native mods are UNSAFE by design:
 - no CPU timeout enforcement
 - full process privileges
 
-Use external mods (`kind = "external"`) when process isolation/timeouts are required.
+Use external guest execution (`execution = "external_guest"`) when process isolation/timeouts are required.

--- a/docs/UNSAFE_NATIVE_MODS.md
+++ b/docs/UNSAFE_NATIVE_MODS.md
@@ -1,6 +1,6 @@
 # Unsafe Native Mods
 
-Native mods (`kind = "native"`) are opt-in and disabled by default.
+Native guest execution is opt-in and disabled by default.
 
 The canonical public guest contract is `freven_guest`. Native loading remains a
 separate unsafe transport path and is not the primary guest contract surface.
@@ -19,6 +19,15 @@ Supported entry points:
 - `freven_client --unsafe-native-mods ...`
 
 When enabled, Freven logs a loud warning because native libraries run with full process privileges.
+
+## Canonical model
+
+Disk-loaded native guests use this semantic model in `mod.toml`:
+
+- `artifact = "native_library"`
+- `execution = "native_guest"`
+- `trust = "trusted"`
+- `policy = "unsafe_native"`
 
 ## On-disk location
 
@@ -67,7 +76,7 @@ See [NATIVE_MOD_ABI_v1.md](./NATIVE_MOD_ABI_v1.md) for exact details.
 ## Policy notes
 
 - Native mods are never loaded unless explicit opt-in is enabled.
-- If an explicitly required disk `mod.toml` resolves to `kind = "native"` while opt-in is disabled, resolution fails with an actionable error that includes the manifest path and enable flag/env.
-- If an explicitly required disk `mod.toml` resolves to `kind = "external"` while external policy is disabled, resolution fails with an actionable error that includes the manifest path and enable flag/env.
-- Builtin native/external candidates may be skipped when the corresponding policy is disabled.
+- If an explicitly required disk `mod.toml` resolves to `policy = "unsafe_native"` while opt-in is disabled, resolution fails with an actionable error that includes the manifest path and enable flag/env.
+- If an explicitly required disk `mod.toml` resolves to `policy = "external_process"` while external policy is disabled, resolution fails with an actionable error that includes the manifest path and enable flag/env.
+- Builtin registrations are no longer modeled as native/external candidates.
 - Native mods are local-only and not treated as server-downloadable artifacts.


### PR DESCRIPTION
Update native and external transport references to use the canonical artifact and execution vocabulary and clarify side-subset lifecycle hosting in the current guest runtime model.

## Summary
This PR updates the SDK transport reference docs to match the current mod architecture vocabulary and runtime behavior more honestly.

It replaces older transport wording with the canonical execution-model language, so native and external docs describe mods in terms of artifact, execution, and policy rather than older `kind`-style terminology. It also clarifies that guest descriptions may declare both client and server lifecycle hooks, while a given runtime session hosts only the active side as a subset of that declared surface.

The goal is to keep the public transport references aligned with the mod architecture v2 model and reduce ambiguity between canonical guest semantics and transport-specific hosting behavior.

## Validation
List what you ran:
- [ ] cargo fmt --all -- --check
- [ ] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [ ] cargo test --workspace --all-features

## freven-sdk dependency
- Does this PR change the pinned `freven-sdk` tag?
  - [x] No
  - [ ] Yes (which tag and why?)

## Notes for reviewers
This is a docs-only change. The main thing to double-check is terminology consistency across the transport docs: they should use the canonical artifact/execution vocabulary and describe native/external as transport mappings of the same `freven_guest` contract.

It is also worth checking that the side-subset lifecycle wording matches the current runtime behavior exactly, especially for dual-side guest declarations that are hosted per active runtime side rather than rejected.