### PR TITLE
Introduce native in-process guest ABI

### DIFF
--- a/crates/freven_guest/src/lib.rs
+++ b/crates/freven_guest/src/lib.rs
@@ -15,8 +15,42 @@ pub const GUEST_CONTRACT_VERSION_1: u32 = 1;
 #[serde(rename_all = "snake_case")]
 pub enum GuestTransport {
     WasmPtrLenV1,
-    NativePtrLenV1,
+    NativeInProcessV1,
     ExternalEnvelopeV1,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NativeGuestInput {
+    pub ptr: *const u8,
+    pub len: usize,
+}
+
+impl NativeGuestInput {
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            ptr: core::ptr::null(),
+            len: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NativeGuestBuffer {
+    pub ptr: *mut u8,
+    pub len: usize,
+}
+
+impl NativeGuestBuffer {
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            ptr: core::ptr::null_mut(),
+            len: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/freven_guest_sdk/README.md
+++ b/crates/freven_guest_sdk/README.md
@@ -8,6 +8,7 @@ canonical `freven_guest` contract and hides the transport boilerplate:
 - guest alloc/dealloc exports
 - `postcard` encode/decode plumbing
 - Wasm export table wiring
+- native in-process export wiring for low-level fixtures/tests
 - lifecycle/action dispatch lookup
 - export-surface validation against the canonical `GuestDescription`
 
@@ -46,9 +47,9 @@ freven_guest_sdk::wasm_guest!(
 hooks, action bindings, negotiated `GuestDescription`, and emitted Wasm export
 surface all come from that one declaration.
 
-`GuestModule` plus `export_wasm_guest!(...)` remain available for lower-level
-fixtures and ABI-focused tests when you intentionally need to wire the raw
-surface yourself.
+`GuestModule` plus `export_wasm_guest!(...)` / `export_native_guest!(...)`
+remain available for lower-level fixtures and ABI-focused tests when you
+intentionally need to wire the raw surface yourself.
 
 ## Current boundaries
 

--- a/crates/freven_guest_sdk/src/lib.rs
+++ b/crates/freven_guest_sdk/src/lib.rs
@@ -6,8 +6,8 @@ use alloc::vec::Vec;
 
 pub use freven_guest::{
     ActionBinding, ActionInput, ActionOutcome, ActionResult, EffectBatch, GUEST_CONTRACT_VERSION_1,
-    GuestDescription, GuestTransport, LifecycleAck, LifecycleHooks, NegotiationRequest,
-    NegotiationResponse, StartInput, TickInput, WorldEffect,
+    GuestDescription, GuestTransport, LifecycleAck, LifecycleHooks, NativeGuestBuffer,
+    NativeGuestInput, NegotiationRequest, NegotiationResponse, StartInput, TickInput, WorldEffect,
 };
 use serde::de::DeserializeOwned;
 
@@ -264,29 +264,15 @@ impl ActionResponse {
 pub mod __private {
     use super::*;
 
-    pub fn guest_alloc(size: u32) -> u32 {
-        let mut buf = Vec::<u8>::with_capacity(size as usize);
-        let ptr = buf.as_mut_ptr();
-        core::mem::forget(buf);
-        ptr as usize as u32
-    }
-
-    pub fn guest_dealloc(ptr: u32, size: u32) {
-        if ptr == 0 {
-            return;
-        }
-        unsafe {
-            let _ = Vec::from_raw_parts(ptr as usize as *mut u8, size as usize, size as usize);
-        }
-    }
-
-    pub fn guest_negotiate(module: &GuestModule, ptr: u32, len: u32) -> u64 {
-        if len > 0 {
-            let input =
-                unsafe { core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) };
+    fn module_negotiate_bytes(
+        module: &GuestModule,
+        input: &[u8],
+        transport: GuestTransport,
+    ) -> Vec<u8> {
+        if !input.is_empty() {
             let request: NegotiationRequest =
                 postcard::from_bytes(input).expect("valid negotiation request");
-            assert_eq!(request.transport, GuestTransport::WasmPtrLenV1);
+            assert_eq!(request.transport, transport);
             assert!(
                 request
                     .supported_contract_versions
@@ -298,35 +284,35 @@ pub mod __private {
             selected_contract_version: GUEST_CONTRACT_VERSION_1,
             description: module.description(),
         };
-        encode_to_guest(&response)
+        postcard::to_allocvec(&response).expect("guest encoding must succeed")
     }
 
-    pub fn guest_start_client(module: &GuestModule, ptr: u32, len: u32) -> u64 {
-        let input = decode_default_input::<StartInput>(ptr, len);
+    fn module_start_client_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
+        let input = decode_default_input::<StartInput>(input);
         module.handle_start_client(&input);
-        encode_lifecycle_ack()
+        encode_lifecycle_ack_bytes()
     }
 
-    pub fn guest_start_server(module: &GuestModule, ptr: u32, len: u32) -> u64 {
-        let input = decode_default_input::<StartInput>(ptr, len);
+    fn module_start_server_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
+        let input = decode_default_input::<StartInput>(input);
         module.handle_start_server(&input);
-        encode_lifecycle_ack()
+        encode_lifecycle_ack_bytes()
     }
 
-    pub fn guest_tick_client(module: &GuestModule, ptr: u32, len: u32) -> u64 {
-        let input = decode_required_input::<TickInput>(ptr, len);
+    fn module_tick_client_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
+        let input = decode_required_input::<TickInput>(input);
         module.handle_tick_client(&input);
-        encode_lifecycle_ack()
+        encode_lifecycle_ack_bytes()
     }
 
-    pub fn guest_tick_server(module: &GuestModule, ptr: u32, len: u32) -> u64 {
-        let input = decode_required_input::<TickInput>(ptr, len);
+    fn module_tick_server_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
+        let input = decode_required_input::<TickInput>(input);
         module.handle_tick_server(&input);
-        encode_lifecycle_ack()
+        encode_lifecycle_ack_bytes()
     }
 
-    pub fn guest_handle_action(module: &GuestModule, ptr: u32, len: u32) -> u64 {
-        let input = if len == 0 {
+    fn module_handle_action_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
+        let input = if input.is_empty() {
             ActionInput {
                 binding_id: 0,
                 player_id: 0,
@@ -337,51 +323,217 @@ pub mod __private {
                 payload: &[],
             }
         } else {
-            let bytes =
-                unsafe { core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) };
-            postcard::from_bytes(bytes).expect("valid action input")
+            postcard::from_bytes(input).expect("valid action input")
         };
 
         let result = module.handle_action(input);
-        encode_to_guest(&result)
+        postcard::to_allocvec(&result).expect("guest encoding must succeed")
     }
 
-    fn decode_default_input<T>(ptr: u32, len: u32) -> T
+    pub fn wasm_guest_alloc(size: u32) -> u32 {
+        let mut buf = Vec::<u8>::with_capacity(size as usize);
+        let ptr = buf.as_mut_ptr();
+        core::mem::forget(buf);
+        ptr as usize as u32
+    }
+
+    pub fn wasm_guest_dealloc(ptr: u32, size: u32) {
+        if ptr == 0 {
+            return;
+        }
+        unsafe {
+            let _ = Vec::from_raw_parts(ptr as usize as *mut u8, size as usize, size as usize);
+        }
+    }
+
+    pub fn wasm_guest_negotiate(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_negotiate_bytes(
+                module,
+                input,
+                GuestTransport::WasmPtrLenV1,
+            ))
+        })
+    }
+
+    pub fn wasm_guest_start_client(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_start_client_bytes(module, input))
+        })
+    }
+
+    pub fn wasm_guest_start_server(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_start_server_bytes(module, input))
+        })
+    }
+
+    pub fn wasm_guest_tick_client(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_tick_client_bytes(module, input))
+        })
+    }
+
+    pub fn wasm_guest_tick_server(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_tick_server_bytes(module, input))
+        })
+    }
+
+    pub fn wasm_guest_handle_action(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_handle_action_bytes(module, input))
+        })
+    }
+
+    // Native guest buffers in the SDK are owned as exact-sized boxed slices.
+    // That keeps deallocation dependent only on (ptr, len) and avoids any Vec
+    // capacity-coupling in the native ABI helper path.
+    // The canonical empty native buffer is null + zero; these helpers never
+    // intentionally produce non-null + zero.
+    pub fn native_guest_alloc(size: usize) -> *mut u8 {
+        if size == 0 {
+            return core::ptr::null_mut();
+        }
+
+        let mut boxed = alloc::vec![0u8; size].into_boxed_slice();
+        let ptr = boxed.as_mut_ptr();
+        let _raw = alloc::boxed::Box::into_raw(boxed);
+        ptr
+    }
+
+    pub fn native_guest_dealloc(buffer: NativeGuestBuffer) {
+        // Canonical empty native buffers are null + zero. Invalid non-null + zero
+        // is treated as no-op here rather than reconstructing ownership from a
+        // malformed buffer shape.
+        if buffer.ptr.is_null() || buffer.len == 0 {
+            return;
+        }
+
+        unsafe {
+            let slice_ptr = core::ptr::slice_from_raw_parts_mut(buffer.ptr, buffer.len);
+            drop(alloc::boxed::Box::from_raw(slice_ptr));
+        }
+    }
+
+    pub fn native_guest_negotiate(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_negotiate_bytes(
+                module,
+                input,
+                GuestTransport::NativeInProcessV1,
+            ))
+        })
+    }
+
+    pub fn native_guest_start_client(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_start_client_bytes(module, input))
+        })
+    }
+
+    pub fn native_guest_start_server(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_start_server_bytes(module, input))
+        })
+    }
+
+    pub fn native_guest_tick_client(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_tick_client_bytes(module, input))
+        })
+    }
+
+    pub fn native_guest_tick_server(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_tick_server_bytes(module, input))
+        })
+    }
+
+    pub fn native_guest_handle_action(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_handle_action_bytes(module, input))
+        })
+    }
+
+    fn decode_default_input<T>(bytes: &[u8]) -> T
     where
         T: Default + serde::de::DeserializeOwned,
     {
-        if len == 0 {
+        if bytes.is_empty() {
             return T::default();
         }
-
-        let bytes = unsafe { core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) };
         postcard::from_bytes(bytes).expect("valid guest input")
     }
 
-    fn decode_required_input<T>(ptr: u32, len: u32) -> T
+    fn decode_required_input<T>(bytes: &[u8]) -> T
     where
         T: serde::de::DeserializeOwned,
     {
-        assert!(len > 0, "guest input must not be empty");
-        let bytes = unsafe { core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) };
+        assert!(!bytes.is_empty(), "guest input must not be empty");
         postcard::from_bytes(bytes).expect("valid guest input")
     }
 
-    fn encode_lifecycle_ack() -> u64 {
-        encode_to_guest(&LifecycleAck::default())
+    fn encode_lifecycle_ack_bytes() -> Vec<u8> {
+        postcard::to_allocvec(&LifecycleAck::default()).expect("guest encoding must succeed")
     }
 
-    fn encode_to_guest<T>(value: &T) -> u64
-    where
-        T: serde::Serialize,
-    {
-        let bytes = postcard::to_allocvec(value).expect("guest encoding must succeed");
+    fn with_wasm_input_bytes<R>(ptr: u32, len: u32, f: impl FnOnce(&[u8]) -> R) -> R {
+        if len == 0 {
+            return f(&[]);
+        }
+
+        let bytes = unsafe { core::slice::from_raw_parts(ptr as usize as *const u8, len as usize) };
+        f(bytes)
+    }
+
+    fn with_native_input_bytes<R>(input: NativeGuestInput, f: impl FnOnce(&[u8]) -> R) -> R {
+        if input.len == 0 {
+            return f(&[]);
+        }
+
+        let bytes = unsafe { core::slice::from_raw_parts(input.ptr, input.len) };
+        f(bytes)
+    }
+
+    fn encode_to_wasm_guest(bytes: &[u8]) -> u64 {
         let len = u32::try_from(bytes.len()).expect("guest buffer length must fit u32");
-        let ptr = guest_alloc(len);
+        let ptr = wasm_guest_alloc(len);
         unsafe {
             core::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr as usize as *mut u8, bytes.len());
         }
         (u64::from(ptr) << 32) | u64::from(len)
+    }
+
+    fn encode_to_native_guest(bytes: Vec<u8>) -> NativeGuestBuffer {
+        if bytes.is_empty() {
+            return NativeGuestBuffer::empty();
+        }
+
+        let mut boxed = bytes.into_boxed_slice();
+        let len = boxed.len();
+        let ptr = boxed.as_mut_ptr();
+        let _raw = alloc::boxed::Box::into_raw(boxed);
+
+        NativeGuestBuffer { ptr, len }
     }
 
     pub fn assert_export_surface(
@@ -413,12 +565,12 @@ macro_rules! export_wasm_guest {
     ) => {
         #[unsafe(no_mangle)]
         pub extern "C" fn freven_guest_alloc(size: u32) -> u32 {
-            $crate::__private::guest_alloc(size)
+            $crate::__private::wasm_guest_alloc(size)
         }
 
         #[unsafe(no_mangle)]
         pub extern "C" fn freven_guest_dealloc(ptr: u32, size: u32) {
-            $crate::__private::guest_dealloc(ptr, size)
+            $crate::__private::wasm_guest_dealloc(ptr, size)
         }
 
         #[unsafe(no_mangle)]
@@ -429,7 +581,7 @@ macro_rules! export_wasm_guest {
                 $crate::export_wasm_guest!(@lifecycle_struct $($($lifecycle),*)?),
                 $crate::export_wasm_guest!(@actions_bool $($actions)?),
             );
-            $crate::__private::guest_negotiate(&module, ptr, len)
+            $crate::__private::wasm_guest_negotiate(&module, ptr, len)
         }
 
         $crate::export_wasm_guest!(@maybe_export $factory, start_client, $($($lifecycle),*)?);
@@ -459,7 +611,7 @@ macro_rules! export_wasm_guest {
         #[unsafe(no_mangle)]
         pub extern "C" fn freven_guest_on_start_client(ptr: u32, len: u32) -> u64 {
             let module = $factory();
-            $crate::__private::guest_start_client(&module, ptr, len)
+            $crate::__private::wasm_guest_start_client(&module, ptr, len)
         }
     };
     (@maybe_export $factory:path, start_client, $_head:ident $(, $rest:ident)*) => {
@@ -472,7 +624,7 @@ macro_rules! export_wasm_guest {
         #[unsafe(no_mangle)]
         pub extern "C" fn freven_guest_on_start_server(ptr: u32, len: u32) -> u64 {
             let module = $factory();
-            $crate::__private::guest_start_server(&module, ptr, len)
+            $crate::__private::wasm_guest_start_server(&module, ptr, len)
         }
     };
     (@maybe_export $factory:path, start_server, $_head:ident $(, $rest:ident)*) => {
@@ -485,7 +637,7 @@ macro_rules! export_wasm_guest {
         #[unsafe(no_mangle)]
         pub extern "C" fn freven_guest_on_tick_client(ptr: u32, len: u32) -> u64 {
             let module = $factory();
-            $crate::__private::guest_tick_client(&module, ptr, len)
+            $crate::__private::wasm_guest_tick_client(&module, ptr, len)
         }
     };
     (@maybe_export $factory:path, tick_client, $_head:ident $(, $rest:ident)*) => {
@@ -498,7 +650,7 @@ macro_rules! export_wasm_guest {
         #[unsafe(no_mangle)]
         pub extern "C" fn freven_guest_on_tick_server(ptr: u32, len: u32) -> u64 {
             let module = $factory();
-            $crate::__private::guest_tick_server(&module, ptr, len)
+            $crate::__private::wasm_guest_tick_server(&module, ptr, len)
         }
     };
     (@maybe_export $factory:path, tick_server, $_head:ident $(, $rest:ident)*) => {
@@ -511,7 +663,136 @@ macro_rules! export_wasm_guest {
         #[unsafe(no_mangle)]
         pub extern "C" fn freven_guest_handle_action(ptr: u32, len: u32) -> u64 {
             let module = $factory();
-            $crate::__private::guest_handle_action(&module, ptr, len)
+            $crate::__private::wasm_guest_handle_action(&module, ptr, len)
+        }
+    };
+    (@maybe_export_action $factory:path, false) => {};
+    (@maybe_export_action $factory:path) => {};
+}
+
+/// Lower-level native export wiring for cases where you intentionally manage a
+/// `GuestModule` factory and export surface separately.
+#[macro_export]
+macro_rules! export_native_guest {
+    (
+        factory: $factory:path
+        $(, lifecycle: [$($lifecycle:ident),* $(,)?])?
+        $(, actions: $actions:tt)?
+        $(,)?
+    ) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_alloc(size: usize) -> *mut u8 {
+            $crate::__private::native_guest_alloc(size)
+        }
+
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_dealloc(buffer: $crate::NativeGuestBuffer) {
+            $crate::__private::native_guest_dealloc(buffer)
+        }
+
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_negotiate(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::assert_export_surface(
+                &module,
+                $crate::export_native_guest!(@lifecycle_struct $($($lifecycle),*)?),
+                $crate::export_native_guest!(@actions_bool $($actions)?),
+            );
+            $crate::__private::native_guest_negotiate(&module, input)
+        }
+
+        $crate::export_native_guest!(@maybe_export $factory, start_client, $($($lifecycle),*)?);
+        $crate::export_native_guest!(@maybe_export $factory, start_server, $($($lifecycle),*)?);
+        $crate::export_native_guest!(@maybe_export $factory, tick_client, $($($lifecycle),*)?);
+        $crate::export_native_guest!(@maybe_export $factory, tick_server, $($($lifecycle),*)?);
+        $crate::export_native_guest!(@maybe_export_action $factory, $($actions)?);
+    };
+
+    (@lifecycle_struct $($hook:ident),*) => {{
+        let mut hooks = $crate::LifecycleHooks::default();
+        $(hooks.$hook = true;)*
+        hooks
+    }};
+
+    (@actions_bool true) => {
+        true
+    };
+    (@actions_bool false) => {
+        false
+    };
+    (@actions_bool) => {
+        false
+    };
+
+    (@maybe_export $factory:path, start_client, start_client $(, $rest:ident)*) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_start_client(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::native_guest_start_client(&module, input)
+        }
+    };
+    (@maybe_export $factory:path, start_client, $_head:ident $(, $rest:ident)*) => {
+        $crate::export_native_guest!(@maybe_export $factory, start_client $(, $rest)*);
+    };
+    (@maybe_export $factory:path, start_client,) => {};
+    (@maybe_export $factory:path, start_client) => {};
+
+    (@maybe_export $factory:path, start_server, start_server $(, $rest:ident)*) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_start_server(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::native_guest_start_server(&module, input)
+        }
+    };
+    (@maybe_export $factory:path, start_server, $_head:ident $(, $rest:ident)*) => {
+        $crate::export_native_guest!(@maybe_export $factory, start_server $(, $rest)*);
+    };
+    (@maybe_export $factory:path, start_server,) => {};
+    (@maybe_export $factory:path, start_server) => {};
+
+    (@maybe_export $factory:path, tick_client, tick_client $(, $rest:ident)*) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_tick_client(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::native_guest_tick_client(&module, input)
+        }
+    };
+    (@maybe_export $factory:path, tick_client, $_head:ident $(, $rest:ident)*) => {
+        $crate::export_native_guest!(@maybe_export $factory, tick_client $(, $rest)*);
+    };
+    (@maybe_export $factory:path, tick_client,) => {};
+    (@maybe_export $factory:path, tick_client) => {};
+
+    (@maybe_export $factory:path, tick_server, tick_server $(, $rest:ident)*) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_tick_server(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::native_guest_tick_server(&module, input)
+        }
+    };
+    (@maybe_export $factory:path, tick_server, $_head:ident $(, $rest:ident)*) => {
+        $crate::export_native_guest!(@maybe_export $factory, tick_server $(, $rest)*);
+    };
+    (@maybe_export $factory:path, tick_server,) => {};
+    (@maybe_export $factory:path, tick_server) => {};
+
+    (@maybe_export_action $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_handle_action(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::native_guest_handle_action(&module, input)
         }
     };
     (@maybe_export_action $factory:path, false) => {};
@@ -799,5 +1080,22 @@ mod tests {
                 ..Default::default()
             }
         );
+    }
+
+    #[test]
+    fn native_guest_alloc_dealloc_round_trips_exact_sized_buffer() {
+        let ptr = __private::native_guest_alloc(16);
+        assert!(!ptr.is_null());
+
+        unsafe {
+            core::ptr::write_bytes(ptr, 0xAB, 16);
+        }
+
+        __private::native_guest_dealloc(NativeGuestBuffer { ptr, len: 16 });
+    }
+
+    #[test]
+    fn native_guest_dealloc_accepts_empty_buffer() {
+        __private::native_guest_dealloc(NativeGuestBuffer::empty());
     }
 }

--- a/docs/EXTERNAL_MOD_IPC_v1.md
+++ b/docs/EXTERNAL_MOD_IPC_v1.md
@@ -1,7 +1,7 @@
 # External Mod IPC v1
 
-This document defines the companion-process protocol for `kind = "external"`
-mods.
+This document defines the companion-process protocol for mods with
+`execution = "external_guest"`.
 
 The canonical public guest contract is `freven_guest` as documented in
 `GUEST_CONTRACT_v1.md`. External is a secondary transport that carries the same
@@ -59,7 +59,8 @@ process boundary.
   lifecycle calls, and action IPC.
 - Negotiation must select `GUEST_CONTRACT_VERSION_1` and return a
   `guest_id` that matches the resolved mod id.
-- Negotiated lifecycle declarations must be side-compatible with the runtime.
+- Negotiated lifecycle declarations may include both client and server hooks.
+  The runtime hosts the active side as a subset for the current session.
 - External transport supports the full `freven_guest` surface; if the guest
   declares a lifecycle hook, the companion process must answer the
   corresponding request with a `lifecycle` response carrying `LifecycleAck`.

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -84,4 +84,4 @@ Native mods are UNSAFE by design:
 - no CPU timeout enforcement
 - full process privileges
 
-Use external mods (`kind = "external"`) when process isolation/timeouts are required.
+Use external guest execution (`execution = "external_guest"`) when process isolation/timeouts are required.

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -5,7 +5,7 @@ Freven native mods.
 
 The canonical public guest contract is `freven_guest` as documented in
 `GUEST_CONTRACT_v1.md`. Native is a secondary unsafe transport that carries the
-same guest negotiation and action semantics over an in-process ptr/len ABI.
+same guest negotiation and action semantics over an in-process native-width ABI.
 
 This is not the recommended public authoring path. Prefer Wasm with
 `freven_guest_sdk` unless you are intentionally doing low-level runtime work on
@@ -15,34 +15,54 @@ trusted local code.
 
 A native mod dynamic library must export these symbols:
 
-- `freven_guest_alloc(size: u32) -> u32`
-- `freven_guest_dealloc(ptr: u32, len: u32)`
-- `freven_guest_negotiate(payload_ptr: u32, payload_len: u32) -> u64`
-- `freven_guest_handle_action(payload_ptr: u32, payload_len: u32) -> u64` when
+- `freven_guest_alloc(size: usize) -> *mut u8`
+- `freven_guest_dealloc(buffer: NativeGuestBuffer)`
+- `freven_guest_negotiate(input: NativeGuestInput) -> NativeGuestBuffer`
+- `freven_guest_handle_action(input: NativeGuestInput) -> NativeGuestBuffer` when
   `action_entrypoint = true`
-- `freven_guest_on_start_client(payload_ptr: u32, payload_len: u32) -> u64`
+- `freven_guest_on_start_client(input: NativeGuestInput) -> NativeGuestBuffer`
   when `lifecycle.start_client = true`
-- `freven_guest_on_start_server(payload_ptr: u32, payload_len: u32) -> u64`
+- `freven_guest_on_start_server(input: NativeGuestInput) -> NativeGuestBuffer`
   when `lifecycle.start_server = true`
-- `freven_guest_on_tick_client(payload_ptr: u32, payload_len: u32) -> u64`
+- `freven_guest_on_tick_client(input: NativeGuestInput) -> NativeGuestBuffer`
   when `lifecycle.tick_client = true`
-- `freven_guest_on_tick_server(payload_ptr: u32, payload_len: u32) -> u64`
+- `freven_guest_on_tick_server(input: NativeGuestInput) -> NativeGuestBuffer`
   when `lifecycle.tick_server = true`
 
-## Packed pointer/len format
+FFI structs:
 
-`freven_guest_negotiate` and `freven_guest_handle_action` return a packed
-`(ptr,len)` value:
+```rust
+#[repr(C)]
+struct NativeGuestInput {
+    ptr: *const u8,
+    len: usize,
+}
 
-- `((ptr as u64) << 32) | (len as u64)`
+#[repr(C)]
+struct NativeGuestBuffer {
+    ptr: *mut u8,
+    len: usize,
+}
+```
 
-Host decodes:
+`usize` tracks the platform-native pointer width. On 64-bit targets the ABI is
+64-bit-safe; on 32-bit targets it naturally narrows with the target ABI.
 
-- `ptr = (packed >> 32) as u32`
-- `len = packed as u32`
+## Memory contract
 
-`ptr/len` refer to process address space memory owned by the native mod.
-Host copies bytes directly and then calls `freven_guest_dealloc(ptr, len)`.
+- Host-to-guest input:
+  - non-empty input: host allocates guest-owned memory with `freven_guest_alloc`
+  - non-empty input: host copies input bytes into that allocation
+  - host calls guest entrypoints with `NativeGuestInput { ptr, len }`
+  - non-empty input: host frees the input allocation with `freven_guest_dealloc`
+  - empty input is passed canonically as `ptr = null` with `len = 0`
+- Guest-to-host output:
+  - guest returns `NativeGuestBuffer { ptr, len }`
+  - buffer refers to process memory owned by the native mod
+  - host copies bytes directly
+  - host frees the returned buffer with `freven_guest_dealloc`
+- Zero-length buffers must use `ptr = null` with `len = 0`
+- Native does not use Wasm-style packed `(ptr,len)` integers anywhere
 
 ## Encoding
 
@@ -67,7 +87,7 @@ Runtime validates and enforces:
 - no duplicate `binding_id` values within one guest description
 - max byte caps for negotiation/result/input payload before copying
 - declared action/lifecycle surface exactly matches the exported symbol surface
-- side-incompatible lifecycle declarations are rejected during attach
+- dual-side lifecycle declarations are allowed; the runtime hosts the active side as a subset for the current session
 
 On decode/validation/contract errors, attach fails.
 On lifecycle or action-call faults, runtime disables that guest mod for the

--- a/docs/UNSAFE_NATIVE_MODS.md
+++ b/docs/UNSAFE_NATIVE_MODS.md
@@ -46,30 +46,40 @@ Absolute paths, root/prefix components, and parent traversal are rejected during
 
 ## ABI boundary
 
-Native mods use the unified ABI surface shared with WASM/runtime contracts:
+Native mods use the same semantic guest contract as Wasm, but not the same
+memory ABI. Native uses explicit in-process FFI structs:
 
-- `freven_guest_alloc(size: u32) -> u32`
-- `freven_guest_dealloc(ptr: u32, len: u32)`
-- `freven_guest_negotiate(payload_ptr: u32, payload_len: u32) -> u64`
-- `freven_guest_handle_action(payload_ptr: u32, payload_len: u32) -> u64`
+- `freven_guest_alloc(size: usize) -> *mut u8`
+- `freven_guest_dealloc(buffer: NativeGuestBuffer)`
+- `freven_guest_negotiate(input: NativeGuestInput) -> NativeGuestBuffer`
+- `freven_guest_handle_action(input: NativeGuestInput) -> NativeGuestBuffer`
 - optional lifecycle exports when declared in `GuestDescription`:
   - `freven_guest_on_start_client`
   - `freven_guest_on_start_server`
   - `freven_guest_on_tick_client`
   - `freven_guest_on_tick_server`
 
-`freven_guest_negotiate` returns postcard bytes for `NegotiationResponse`
-packed as `(ptr,len)`.
-`freven_guest_handle_action` returns postcard bytes for `ActionResult` packed as
-`(ptr,len)`.
-Lifecycle exports return postcard bytes for `LifecycleAck` packed as `(ptr,len)`.
+`NativeGuestInput` is `#[repr(C)] { ptr: *const u8, len: usize }`.
+`NativeGuestBuffer` is `#[repr(C)] { ptr: *mut u8, len: usize }`.
+
+Zero-length native inputs and outputs are canonical only as `ptr = null` with `len = 0`.
+Non-null zero-length buffers are invalid.
+
+`freven_guest_negotiate` returns postcard bytes for `NegotiationResponse`.
+`freven_guest_handle_action` returns postcard bytes for `ActionResult`.
+Lifecycle exports return postcard bytes for `LifecycleAck`.
 Action input bytes passed to `freven_guest_handle_action` are postcard
 `ActionInput`, which is the only authority for action binding and runtime
 action context.
 
-Packed format matches WASM ABI v1 exactly:
+For non-empty input, the host allocates guest-owned input buffers with
+`freven_guest_alloc`, passes them by `NativeGuestInput`, and releases them with
+`freven_guest_dealloc`. Empty input is passed canonically as `ptr = null` with
+`len = 0`.
 
-- `((ptr as u64) << 32) | (len as u64)`
+Returned `NativeGuestBuffer` values are copied and then released with
+`freven_guest_dealloc`. Zero-length output is canonical only as `ptr = null`
+with `len = 0`.
 
 See [NATIVE_MOD_ABI_v1.md](./NATIVE_MOD_ABI_v1.md) for exact details.
 

--- a/docs/UNSAFE_NATIVE_MODS.md
+++ b/docs/UNSAFE_NATIVE_MODS.md
@@ -1,6 +1,6 @@
 # Unsafe Native Mods
 
-Native mods (`kind = "native"`) are opt-in and disabled by default.
+Native guest execution is opt-in and disabled by default.
 
 The canonical public guest contract is `freven_guest`. Native loading remains a
 separate unsafe transport path and is not the primary guest contract surface.
@@ -19,6 +19,15 @@ Supported entry points:
 - `freven_client --unsafe-native-mods ...`
 
 When enabled, Freven logs a loud warning because native libraries run with full process privileges.
+
+## Canonical model
+
+Disk-loaded native guests use this semantic model in `mod.toml`:
+
+- `artifact = "native_library"`
+- `execution = "native_guest"`
+- `trust = "trusted"`
+- `policy = "unsafe_native"`
 
 ## On-disk location
 
@@ -67,7 +76,7 @@ See [NATIVE_MOD_ABI_v1.md](./NATIVE_MOD_ABI_v1.md) for exact details.
 ## Policy notes
 
 - Native mods are never loaded unless explicit opt-in is enabled.
-- If an explicitly required disk `mod.toml` resolves to `kind = "native"` while opt-in is disabled, resolution fails with an actionable error that includes the manifest path and enable flag/env.
-- If an explicitly required disk `mod.toml` resolves to `kind = "external"` while external policy is disabled, resolution fails with an actionable error that includes the manifest path and enable flag/env.
-- Builtin native/external candidates may be skipped when the corresponding policy is disabled.
+- If an explicitly required disk `mod.toml` resolves to `policy = "unsafe_native"` while opt-in is disabled, resolution fails with an actionable error that includes the manifest path and enable flag/env.
+- If an explicitly required disk `mod.toml` resolves to `policy = "external_process"` while external policy is disabled, resolution fails with an actionable error that includes the manifest path and enable flag/env.
+- Builtin registrations are no longer modeled as native/external candidates.
 - Native mods are local-only and not treated as server-downloadable artifacts.


### PR DESCRIPTION
Add native-width guest buffer types to freven_guest, rename the native transport to NativeInProcessV1, and extend freven_guest_sdk with native export helpers so low-level native fixtures and tests can target the canonical contract without Wasm-style packed ptr/len shims.

## Summary
What does this PR change? Why?

This PR introduces a native in-process ABI surface for freven_guest based on explicit NativeGuestInput and NativeGuestBuffer structs instead of packed integer ptr/len pairs. It also updates freven_guest_sdk to expose native export wiring helpers alongside the existing Wasm helpers, and refreshes the native transport docs to describe the memory contract, native-width pointer semantics, and canonical empty-buffer rules.

The goal is to make the native transport ABI explicit and 64-bit-safe while keeping the semantic guest contract transport-agnostic. This removes an unnecessary Wasm-style encoding from native execution paths and gives runtime/fixture code a clearer contract to implement and validate.

## Validation
List what you ran:
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo test --workspace --all-features

## freven-sdk dependency
- Does this PR change the pinned `freven-sdk` tag?
  - [x] No
  - [ ] Yes (which tag and why?)

## Notes for reviewers
- The most important detail is the native empty-buffer convention: zero-length native buffers are canonical only as `ptr = null` with `len = 0`.
- `freven_guest_sdk` intentionally treats malformed native zero-length buffers conservatively in helper deallocation paths, so it is worth double-checking that this matches the intended fixture/test behavior.
- The semantic guest contract is unchanged; this PR only changes the native memory ABI and supporting authoring/test helpers.