### PR TITLE
Expand and validate canonical guest registrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
 name = "freven_guest"
 version = "0.1.0"
 dependencies = [
+ "freven_sdk_types",
  "serde",
 ]
 
@@ -51,6 +52,7 @@ name = "freven_guest_sdk"
 version = "0.1.0"
 dependencies = [
  "freven_guest",
+ "freven_sdk_types",
  "postcard",
  "serde",
 ]

--- a/crates/freven_api/src/lib.rs
+++ b/crates/freven_api/src/lib.rs
@@ -452,6 +452,11 @@ pub enum ModRegistrationError {
         registry: &'static str,
         key: String,
     },
+    #[error("empty {registry} key registered by mod '{mod_id}'")]
+    EmptyKey {
+        mod_id: String,
+        registry: &'static str,
+    },
     #[error("too many blocks registered by mod '{mod_id}' for key '{key}': limit is {limit}")]
     TooManyBlocks {
         mod_id: String,
@@ -466,6 +471,16 @@ pub enum ModRegistrationError {
         key: String,
         reliability: ChannelReliability,
         ordering: ChannelOrdering,
+    },
+    #[error(
+        "mod '{mod_id}' declared capability '{key}' but it is not present in the resolved capability table"
+    )]
+    UndeclaredCapability { mod_id: String, key: String },
+    #[error("invalid {kind} declaration for mod '{mod_id}': {reason}")]
+    InvalidDeclaration {
+        mod_id: String,
+        kind: &'static str,
+        reason: String,
     },
 }
 

--- a/crates/freven_guest/Cargo.toml
+++ b/crates/freven_guest/Cargo.toml
@@ -6,4 +6,5 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+freven_sdk_types.workspace = true
 serde.workspace = true

--- a/crates/freven_guest/src/lib.rs
+++ b/crates/freven_guest/src/lib.rs
@@ -7,6 +7,7 @@
 extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
+use freven_sdk_types::blocks::BlockDef;
 use serde::{Deserialize, Serialize};
 
 pub const GUEST_CONTRACT_VERSION_1: u32 = 1;
@@ -59,18 +60,35 @@ pub struct NegotiationRequest {
     pub transport: GuestTransport,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NegotiationResponse {
     pub selected_contract_version: u32,
     pub description: GuestDescription,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GuestDescription {
     pub guest_id: String,
+    pub registration: GuestRegistration,
+    pub callbacks: GuestCallbacks,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GuestRegistration {
+    pub blocks: Vec<BlockDeclaration>,
+    pub components: Vec<ComponentDeclaration>,
+    pub messages: Vec<MessageDeclaration>,
+    pub channels: Vec<ChannelDeclaration>,
+    pub actions: Vec<ActionDeclaration>,
+    pub capabilities: Vec<CapabilityDeclaration>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GuestCallbacks {
     pub lifecycle: LifecycleHooks,
-    pub action_entrypoint: bool,
-    pub actions: Vec<ActionBinding>,
+    pub action: bool,
+    pub server_messages: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -81,10 +99,87 @@ pub struct LifecycleHooks {
     pub tick_server: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockDeclaration {
+    pub key: String,
+    pub def: BlockDef,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ActionBinding {
+pub struct ComponentDeclaration {
+    pub key: String,
+    pub codec: ComponentCodec,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentCodec {
+    RawBytes,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageDeclaration {
+    pub key: String,
+    pub codec: MessageCodec,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageCodec {
+    RawBytes,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChannelDeclaration {
+    pub key: String,
+    pub config: ChannelConfig,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChannelConfig {
+    pub reliability: ChannelReliability,
+    pub ordering: ChannelOrdering,
+    pub direction: ChannelDirection,
+    pub budget: Option<ChannelBudget>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelReliability {
+    Reliable,
+    Unreliable,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelOrdering {
+    Ordered,
+    Unordered,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelDirection {
+    ClientToServer,
+    ServerToClient,
+    Bidirectional,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChannelBudget {
+    pub max_messages_per_sec: Option<u32>,
+    pub max_bytes_per_sec: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActionDeclaration {
     pub key: String,
     pub binding_id: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityDeclaration {
+    pub key: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -96,7 +191,7 @@ pub struct TickInput {
     pub dt_millis: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ActionInput<'a> {
     pub binding_id: u32,
     pub player_id: u64,
@@ -104,8 +199,16 @@ pub struct ActionInput<'a> {
     pub stream_epoch: u32,
     pub action_seq: u32,
     pub at_input_seq: u32,
+    pub player_position_m: Option<[f32; 3]>,
     #[serde(borrow)]
     pub payload: &'a [u8],
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerMessageInput {
+    pub tick: u64,
+    pub dt_millis: u32,
+    pub messages: Vec<ServerInboundMessage>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -115,6 +218,12 @@ pub struct LifecycleAck {}
 pub struct ActionResult {
     pub outcome: ActionOutcome,
     pub effects: EffectBatch,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ServerMessageResult {
+    pub outbound: Vec<ServerOutboundMessage>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -140,4 +249,31 @@ impl EffectBatch {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum WorldEffect {
     SetBlock { pos: (i32, i32, i32), block_id: u8 },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerOutboundMessage {
+    pub player_id: u64,
+    pub scope: MessageScope,
+    pub channel_id: u32,
+    pub message_id: u32,
+    pub seq: Option<u32>,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerInboundMessage {
+    pub player_id: u64,
+    pub scope: MessageScope,
+    pub channel_id: u32,
+    pub message_id: u32,
+    pub seq: Option<u32>,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageScope {
+    Global,
+    Level { level_id: u32, stream_epoch: u32 },
 }

--- a/crates/freven_guest_sdk/Cargo.toml
+++ b/crates/freven_guest_sdk/Cargo.toml
@@ -7,5 +7,6 @@ publish.workspace = true
 
 [dependencies]
 freven_guest.workspace = true
+freven_sdk_types.workspace = true
 postcard.workspace = true
 serde.workspace = true

--- a/crates/freven_guest_sdk/README.md
+++ b/crates/freven_guest_sdk/README.md
@@ -9,7 +9,8 @@ canonical `freven_guest` contract and hides the transport boilerplate:
 - `postcard` encode/decode plumbing
 - Wasm export table wiring
 - native in-process export wiring for low-level fixtures/tests
-- lifecycle/action dispatch lookup
+- canonical declaration builders for blocks/components/messages/channels/actions/capabilities
+- lifecycle/action/server-message dispatch lookup
 - export-surface validation against the canonical `GuestDescription`
 
 Most mod authors should depend on `freven_guest_sdk`. Reach for
@@ -43,9 +44,9 @@ freven_guest_sdk::wasm_guest!(
 );
 ```
 
-`wasm_guest!` is the normal public authoring path: the guest id, lifecycle
-hooks, action bindings, negotiated `GuestDescription`, and emitted Wasm export
-surface all come from that one declaration.
+`wasm_guest!` is the normal public authoring path: the guest id, registration
+families, callback families, negotiated `GuestDescription`, and emitted Wasm
+export surface all come from that one declaration.
 
 `GuestModule` plus `export_wasm_guest!(...)` / `export_native_guest!(...)`
 remain available for lower-level fixtures and ABI-focused tests when you
@@ -53,8 +54,11 @@ intentionally need to wire the raw surface yourself.
 
 ## Current boundaries
 
-- Lifecycle hooks are ack-only because contract v1 does not expose lifecycle
-  output payloads yet.
+- Lifecycle hooks are still ack-only.
+- Server-side runtime messaging is now a dedicated callback family
+  (`on_server_messages`) rather than being stuffed into actions.
+- Declarations now cover blocks, components, messages, channels, actions, and
+  capability keys in one transport-neutral registration model.
 - Guest-side persistent instance state is not modeled by the SDK today. Use
   explicit statics only when you fully control the implications.
 - Wasm is the primary safe path. Native and external transports remain

--- a/crates/freven_guest_sdk/README.md
+++ b/crates/freven_guest_sdk/README.md
@@ -55,10 +55,16 @@ intentionally need to wire the raw surface yourself.
 ## Current boundaries
 
 - Lifecycle hooks are still ack-only.
+- `registration.actions` and `callbacks.action` stay coupled:
+  actions imply the callback family, and the callback family is not valid without declared actions.
 - Server-side runtime messaging is now a dedicated callback family
   (`on_server_messages`) rather than being stuffed into actions.
+- Runtime delivery of server messages is contract-checked symmetrically:
+  undeclared inbound channels/message ids fault the guest the same way undeclared outbound use does.
 - Declarations now cover blocks, components, messages, channels, actions, and
   capability keys in one transport-neutral registration model.
+- Capability declarations are validated honestly by the runtime:
+  empty keys fail, and unknown capability keys are rejected against host policy.
 - Guest-side persistent instance state is not modeled by the SDK today. Use
   explicit statics only when you fully control the implications.
 - Wasm is the primary safe path. Native and external transports remain

--- a/crates/freven_guest_sdk/src/lib.rs
+++ b/crates/freven_guest_sdk/src/lib.rs
@@ -1132,20 +1132,21 @@ macro_rules! wasm_guest {
         );
     };
 
-    (@registration $module:ident,) => { $module };
-    (@registration $module:ident, block: $key:expr => $def:expr $(, $($rest:tt)*)?) => {
+    (@registration $module:expr) => { $module };
+    (@registration $module:expr,) => { $module };
+    (@registration $module:expr, block: $key:expr => $def:expr $(, $($rest:tt)*)?) => {
         $crate::wasm_guest!(@registration $module.register_block($key, $def) $(, $($rest)*)?)
     };
-    (@registration $module:ident, component: $key:expr => $codec:expr $(, $($rest:tt)*)?) => {
+    (@registration $module:expr, component: $key:expr => $codec:expr $(, $($rest:tt)*)?) => {
         $crate::wasm_guest!(@registration $module.register_component($key, $codec) $(, $($rest)*)?)
     };
-    (@registration $module:ident, message: $key:expr => $codec:expr $(, $($rest:tt)*)?) => {
+    (@registration $module:expr, message: $key:expr => $codec:expr $(, $($rest:tt)*)?) => {
         $crate::wasm_guest!(@registration $module.register_message($key, $codec) $(, $($rest)*)?)
     };
-    (@registration $module:ident, channel: $key:expr => $config:expr $(, $($rest:tt)*)?) => {
+    (@registration $module:expr, channel: $key:expr => $config:expr $(, $($rest:tt)*)?) => {
         $crate::wasm_guest!(@registration $module.register_channel($key, $config) $(, $($rest)*)?)
     };
-    (@registration $module:ident, capability: $key:expr $(, $($rest:tt)*)?) => {
+    (@registration $module:expr, capability: $key:expr $(, $($rest:tt)*)?) => {
         $crate::wasm_guest!(@registration $module.declare_capability($key) $(, $($rest)*)?)
     };
 }
@@ -1153,6 +1154,15 @@ macro_rules! wasm_guest {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn message_channel() -> ChannelConfig {
+        ChannelConfig {
+            reliability: ChannelReliability::Reliable,
+            ordering: ChannelOrdering::Ordered,
+            direction: ChannelDirection::Bidirectional,
+            budget: None,
+        }
+    }
 
     fn module() -> GuestModule {
         GuestModule::new("freven.test.guest")
@@ -1168,15 +1178,7 @@ mod tests {
             )
             .register_component("freven.test:name", ComponentCodec::RawBytes)
             .register_message("freven.test:echo", MessageCodec::RawBytes)
-            .register_channel(
-                "freven.test:echo",
-                ChannelConfig {
-                    reliability: ChannelReliability::Reliable,
-                    ordering: ChannelOrdering::Ordered,
-                    direction: ChannelDirection::Bidirectional,
-                    budget: None,
-                },
-            )
+            .register_channel("freven.test:echo", message_channel())
             .declare_capability("max_call_millis")
             .on_start_server(|_| {})
             .on_tick_server(|_| {})
@@ -1196,6 +1198,12 @@ mod tests {
             .action("freven.test:place_block", 7, |_| {
                 ActionResponse::applied().set_block((1, 2, 3), 9)
             })
+    }
+
+    #[test]
+    #[should_panic(expected = "freven_guest_sdk guest_id must not be empty")]
+    fn empty_guest_id_panics() {
+        let _ = GuestModule::new("");
     }
 
     #[test]
@@ -1247,5 +1255,176 @@ mod tests {
         });
         assert_eq!(result.outbound.len(), 1);
         assert_eq!(result.outbound[0].payload, b"hello");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "freven_guest_sdk capability key 'freven.test:dup' was registered more than once"
+    )]
+    fn duplicate_capability_keys_panic() {
+        let _ = GuestModule::new("freven.test.guest")
+            .declare_capability("freven.test:dup")
+            .declare_capability("freven.test:dup");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "freven_guest_sdk action key 'freven.test:dup' was registered more than once"
+    )]
+    fn duplicate_action_keys_panic() {
+        let _ = GuestModule::new("freven.test.guest")
+            .action("freven.test:dup", 7, |_| ActionResponse::applied())
+            .action("freven.test:dup", 8, |_| ActionResponse::applied());
+    }
+
+    #[test]
+    #[should_panic(expected = "freven_guest_sdk action key must not be empty")]
+    fn empty_action_keys_panic() {
+        let _ = GuestModule::new("freven.test.guest").action("", 7, |_| ActionResponse::applied());
+    }
+
+    #[test]
+    #[should_panic(expected = "freven_guest_sdk action key must not be empty")]
+    fn whitespace_only_action_keys_panic() {
+        let _ =
+            GuestModule::new("freven.test.guest").action("   ", 7, |_| ActionResponse::applied());
+    }
+
+    #[test]
+    #[should_panic(expected = "freven_guest_sdk binding id 7 was registered more than once")]
+    fn duplicate_action_binding_ids_panic() {
+        let _ = GuestModule::new("freven.test.guest")
+            .action("freven.test:a", 7, |_| ActionResponse::applied())
+            .action("freven.test:b", 7, |_| ActionResponse::applied());
+    }
+
+    #[test]
+    fn callbacks_action_tracks_declared_actions_only() {
+        let no_actions = GuestModule::new("freven.test.guest");
+        assert!(!no_actions.callbacks().action);
+
+        let with_action = GuestModule::new("freven.test.guest")
+            .action("freven.test:a", 1, |_| ActionResponse::rejected());
+        assert!(with_action.callbacks().action);
+    }
+
+    #[test]
+    fn export_surface_assertion_happy_path() {
+        let module = module();
+        __private::assert_export_surface(
+            &module,
+            LifecycleHooks {
+                start_server: true,
+                tick_server: true,
+                ..Default::default()
+            },
+            true,
+            true,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "freven_guest_sdk export lifecycle does not match")]
+    fn export_surface_assertion_rejects_lifecycle_mismatch() {
+        __private::assert_export_surface(&module(), LifecycleHooks::default(), true, true);
+    }
+
+    #[test]
+    #[should_panic(expected = "freven_guest_sdk action export does not match")]
+    fn export_surface_assertion_rejects_action_mismatch() {
+        __private::assert_export_surface(
+            &module(),
+            LifecycleHooks {
+                start_server: true,
+                tick_server: true,
+                ..Default::default()
+            },
+            false,
+            true,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "freven_guest_sdk server message export does not match")]
+    fn export_surface_assertion_rejects_server_message_mismatch() {
+        __private::assert_export_surface(
+            &module(),
+            LifecycleHooks {
+                start_server: true,
+                tick_server: true,
+                ..Default::default()
+            },
+            true,
+            false,
+        );
+    }
+
+    #[test]
+    fn wasm_guest_macro_keeps_surface_and_registration_coherent() {
+        let module = wasm_guest!(
+            @module
+            guest_id: "freven.test.macro"
+            , registration: {
+                message: "freven.test:macro_message" => MessageCodec::RawBytes,
+                channel: "freven.test:macro_channel" => message_channel(),
+                capability: "max_call_millis"
+            }
+            , lifecycle: {
+                start_server: |_| {},
+                tick_server: |_| {}
+            }
+            , server_messages: |_| ServerMessageResponse::default()
+            , actions: {
+                "freven.test:macro_action" => {
+                    binding_id: 17,
+                    handler: |_| ActionResponse::applied(),
+                }
+            }
+        );
+
+        let description = module.description();
+        assert_eq!(description.guest_id, "freven.test.macro");
+        assert_eq!(
+            description.registration.messages[0].key,
+            "freven.test:macro_message"
+        );
+        assert_eq!(
+            description.registration.channels[0].key,
+            "freven.test:macro_channel"
+        );
+        assert_eq!(
+            description.registration.actions[0],
+            ActionDeclaration {
+                key: "freven.test:macro_action".to_string(),
+                binding_id: 17,
+            }
+        );
+        assert_eq!(
+            description.registration.capabilities[0].key,
+            "max_call_millis"
+        );
+        assert_eq!(
+            description.callbacks.lifecycle,
+            LifecycleHooks {
+                start_server: true,
+                tick_server: true,
+                ..Default::default()
+            }
+        );
+        assert!(description.callbacks.action);
+        assert!(description.callbacks.server_messages);
+    }
+
+    #[test]
+    fn native_alloc_and_dealloc_helpers_round_trip() {
+        let ptr = __private::native_guest_alloc(4);
+        assert!(!ptr.is_null());
+
+        unsafe {
+            core::ptr::copy_nonoverlapping(b"rust".as_ptr(), ptr, 4);
+        }
+
+        __private::native_guest_dealloc(NativeGuestBuffer { ptr, len: 4 });
+        __private::native_guest_dealloc(NativeGuestBuffer::empty());
     }
 }

--- a/crates/freven_guest_sdk/src/lib.rs
+++ b/crates/freven_guest_sdk/src/lib.rs
@@ -5,23 +5,36 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 pub use freven_guest::{
-    ActionBinding, ActionInput, ActionOutcome, ActionResult, EffectBatch, GUEST_CONTRACT_VERSION_1,
-    GuestDescription, GuestTransport, LifecycleAck, LifecycleHooks, NativeGuestBuffer,
-    NativeGuestInput, NegotiationRequest, NegotiationResponse, StartInput, TickInput, WorldEffect,
+    ActionDeclaration, ActionInput, ActionOutcome, ActionResult, BlockDeclaration,
+    CapabilityDeclaration, ChannelBudget, ChannelConfig, ChannelDeclaration, ChannelDirection,
+    ChannelOrdering, ChannelReliability, ComponentCodec, ComponentDeclaration, EffectBatch,
+    GUEST_CONTRACT_VERSION_1, GuestCallbacks, GuestDescription, GuestRegistration, GuestTransport,
+    LifecycleAck, LifecycleHooks, MessageCodec, MessageDeclaration, MessageScope,
+    NativeGuestBuffer, NativeGuestInput, NegotiationRequest, NegotiationResponse,
+    ServerInboundMessage, ServerMessageInput, ServerMessageResult, ServerOutboundMessage,
+    StartInput, TickInput, WorldEffect,
 };
+pub use freven_sdk_types::blocks::{BlockDef, RenderLayer};
 use serde::de::DeserializeOwned;
 
 type StartHandler = fn(&StartInput);
 type TickHandler = fn(&TickInput);
 type ActionHandler = fn(ActionContext<'_>) -> ActionResponse;
+type ServerMessageHandler = fn(ServerMessageContext<'_>) -> ServerMessageResponse;
 
 pub struct GuestModule {
     guest_id: &'static str,
+    blocks: Vec<BlockDeclaration>,
+    components: Vec<ComponentDeclaration>,
+    messages: Vec<MessageDeclaration>,
+    channels: Vec<ChannelDeclaration>,
     actions: Vec<GuestAction>,
+    capabilities: Vec<CapabilityDeclaration>,
     on_start_client: Option<StartHandler>,
     on_start_server: Option<StartHandler>,
     on_tick_client: Option<TickHandler>,
     on_tick_server: Option<TickHandler>,
+    on_server_messages: Option<ServerMessageHandler>,
 }
 
 impl GuestModule {
@@ -33,12 +46,87 @@ impl GuestModule {
         );
         Self {
             guest_id,
+            blocks: Vec::new(),
+            components: Vec::new(),
+            messages: Vec::new(),
+            channels: Vec::new(),
             actions: Vec::new(),
+            capabilities: Vec::new(),
             on_start_client: None,
             on_start_server: None,
             on_tick_client: None,
             on_tick_server: None,
+            on_server_messages: None,
         }
+    }
+
+    #[must_use]
+    pub fn register_block(mut self, key: &'static str, def: BlockDef) -> Self {
+        assert_unique_key(
+            "block",
+            key,
+            self.blocks.iter().map(|entry| entry.key.as_str()),
+        );
+        self.blocks.push(BlockDeclaration {
+            key: key.to_string(),
+            def,
+        });
+        self
+    }
+
+    #[must_use]
+    pub fn register_component(mut self, key: &'static str, codec: ComponentCodec) -> Self {
+        assert_unique_key(
+            "component",
+            key,
+            self.components.iter().map(|entry| entry.key.as_str()),
+        );
+        self.components.push(ComponentDeclaration {
+            key: key.to_string(),
+            codec,
+        });
+        self
+    }
+
+    #[must_use]
+    pub fn register_message(mut self, key: &'static str, codec: MessageCodec) -> Self {
+        assert_unique_key(
+            "message",
+            key,
+            self.messages.iter().map(|entry| entry.key.as_str()),
+        );
+        self.messages.push(MessageDeclaration {
+            key: key.to_string(),
+            codec,
+        });
+        self
+    }
+
+    #[must_use]
+    pub fn register_channel(mut self, key: &'static str, config: ChannelConfig) -> Self {
+        assert_unique_key(
+            "channel",
+            key,
+            self.channels.iter().map(|entry| entry.key.as_str()),
+        );
+        self.channels.push(ChannelDeclaration {
+            key: key.to_string(),
+            config,
+        });
+        self
+    }
+
+    #[must_use]
+    pub fn declare_capability(mut self, key: &'static str) -> Self {
+        assert_unique_key(
+            "capability",
+            key,
+            self.capabilities.iter().map(|entry| entry.key.as_str()),
+        );
+        self.capabilities.push(CapabilityDeclaration {
+            key: key.to_string(),
+        });
+        self
     }
 
     #[must_use]
@@ -66,15 +154,14 @@ impl GuestModule {
     }
 
     #[must_use]
+    pub fn on_server_messages(mut self, handler: ServerMessageHandler) -> Self {
+        self.on_server_messages = Some(handler);
+        self
+    }
+
+    #[must_use]
     pub fn action(mut self, key: &'static str, binding_id: u32, handler: ActionHandler) -> Self {
-        assert!(
-            !key.trim().is_empty(),
-            "freven_guest_sdk action key must not be empty"
-        );
-        assert!(
-            self.actions.iter().all(|action| action.key != key),
-            "freven_guest_sdk action key '{key}' was registered more than once"
-        );
+        assert_unique_key("action", key, self.actions.iter().map(|entry| entry.key));
         assert!(
             self.actions
                 .iter()
@@ -105,19 +192,34 @@ impl GuestModule {
     }
 
     #[must_use]
+    pub fn callbacks(&self) -> GuestCallbacks {
+        GuestCallbacks {
+            lifecycle: self.lifecycle_hooks(),
+            action: !self.actions.is_empty(),
+            server_messages: self.on_server_messages.is_some(),
+        }
+    }
+
+    #[must_use]
     pub fn description(&self) -> GuestDescription {
         GuestDescription {
             guest_id: self.guest_id.to_string(),
-            lifecycle: self.lifecycle_hooks(),
-            action_entrypoint: !self.actions.is_empty(),
-            actions: self
-                .actions
-                .iter()
-                .map(|action| ActionBinding {
-                    key: action.key.to_string(),
-                    binding_id: action.binding_id,
-                })
-                .collect(),
+            registration: GuestRegistration {
+                blocks: self.blocks.clone(),
+                components: self.components.clone(),
+                messages: self.messages.clone(),
+                channels: self.channels.clone(),
+                actions: self
+                    .actions
+                    .iter()
+                    .map(|action| ActionDeclaration {
+                        key: action.key.to_string(),
+                        binding_id: action.binding_id,
+                    })
+                    .collect(),
+                capabilities: self.capabilities.clone(),
+            },
+            callbacks: self.callbacks(),
         }
     }
 
@@ -157,6 +259,25 @@ impl GuestModule {
 
         (action.handler)(ActionContext { input }).finish()
     }
+
+    #[must_use]
+    pub fn handle_server_messages(&self, input: ServerMessageInput) -> ServerMessageResult {
+        let Some(handler) = self.on_server_messages else {
+            return ServerMessageResponse::default().finish();
+        };
+        handler(ServerMessageContext { input: &input }).finish()
+    }
+}
+
+fn assert_unique_key<'a>(kind: &str, key: &'static str, existing: impl Iterator<Item = &'a str>) {
+    assert!(
+        !key.trim().is_empty(),
+        "freven_guest_sdk {kind} key must not be empty"
+    );
+    assert!(
+        existing.into_iter().all(|entry| entry != key),
+        "freven_guest_sdk {kind} key '{key}' was registered more than once"
+    );
 }
 
 struct GuestAction {
@@ -203,6 +324,11 @@ impl<'a> ActionContext<'a> {
     #[must_use]
     pub fn at_input_seq(&self) -> u32 {
         self.input.at_input_seq
+    }
+
+    #[must_use]
+    pub fn player_position_m(&self) -> Option<[f32; 3]> {
+        self.input.player_position_m
     }
 
     #[must_use]
@@ -256,6 +382,47 @@ impl ActionResponse {
         ActionResult {
             outcome: self.outcome,
             effects: self.effects,
+        }
+    }
+}
+
+pub struct ServerMessageContext<'a> {
+    input: &'a ServerMessageInput,
+}
+
+impl<'a> ServerMessageContext<'a> {
+    #[must_use]
+    pub fn tick(&self) -> u64 {
+        self.input.tick
+    }
+
+    #[must_use]
+    pub fn dt_millis(&self) -> u32 {
+        self.input.dt_millis
+    }
+
+    #[must_use]
+    pub fn messages(&self) -> &'a [ServerInboundMessage] {
+        &self.input.messages
+    }
+}
+
+#[derive(Default)]
+pub struct ServerMessageResponse {
+    outbound: Vec<ServerOutboundMessage>,
+}
+
+impl ServerMessageResponse {
+    #[must_use]
+    pub fn send_to(mut self, message: ServerOutboundMessage) -> Self {
+        self.outbound.push(message);
+        self
+    }
+
+    #[must_use]
+    pub fn finish(self) -> ServerMessageResult {
+        ServerMessageResult {
+            outbound: self.outbound,
         }
     }
 }
@@ -320,6 +487,7 @@ pub mod __private {
                 stream_epoch: 0,
                 action_seq: 0,
                 at_input_seq: 0,
+                player_position_m: None,
                 payload: &[],
             }
         } else {
@@ -328,6 +496,12 @@ pub mod __private {
 
         let result = module.handle_action(input);
         postcard::to_allocvec(&result).expect("guest encoding must succeed")
+    }
+
+    fn module_server_messages_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
+        let input = decode_required_input::<ServerMessageInput>(input);
+        postcard::to_allocvec(&module.handle_server_messages(input))
+            .expect("guest encoding must succeed")
     }
 
     pub fn wasm_guest_alloc(size: u32) -> u32 {
@@ -386,11 +560,12 @@ pub mod __private {
         })
     }
 
-    // Native guest buffers in the SDK are owned as exact-sized boxed slices.
-    // That keeps deallocation dependent only on (ptr, len) and avoids any Vec
-    // capacity-coupling in the native ABI helper path.
-    // The canonical empty native buffer is null + zero; these helpers never
-    // intentionally produce non-null + zero.
+    pub fn wasm_guest_server_messages(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_server_messages_bytes(module, input))
+        })
+    }
+
     pub fn native_guest_alloc(size: usize) -> *mut u8 {
         if size == 0 {
             return core::ptr::null_mut();
@@ -403,9 +578,6 @@ pub mod __private {
     }
 
     pub fn native_guest_dealloc(buffer: NativeGuestBuffer) {
-        // Canonical empty native buffers are null + zero. Invalid non-null + zero
-        // is treated as no-op here rather than reconstructing ownership from a
-        // malformed buffer shape.
         if buffer.ptr.is_null() || buffer.len == 0 {
             return;
         }
@@ -474,6 +646,15 @@ pub mod __private {
         })
     }
 
+    pub fn native_guest_server_messages(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_server_messages_bytes(module, input))
+        })
+    }
+
     fn decode_default_input<T>(bytes: &[u8]) -> T
     where
         T: Default + serde::de::DeserializeOwned,
@@ -539,28 +720,32 @@ pub mod __private {
     pub fn assert_export_surface(
         module: &GuestModule,
         lifecycle: LifecycleHooks,
-        action_entrypoint: bool,
+        action: bool,
+        server_messages: bool,
     ) {
-        let description = module.description();
+        let callbacks = module.description().callbacks;
         assert_eq!(
-            description.lifecycle, lifecycle,
+            callbacks.lifecycle, lifecycle,
             "freven_guest_sdk export lifecycle does not match GuestModule::description()",
         );
         assert_eq!(
-            description.action_entrypoint, action_entrypoint,
+            callbacks.action, action,
             "freven_guest_sdk action export does not match GuestModule::description()",
+        );
+        assert_eq!(
+            callbacks.server_messages, server_messages,
+            "freven_guest_sdk server message export does not match GuestModule::description()",
         );
     }
 }
 
-/// Lower-level Wasm export wiring for cases where you intentionally manage a
-/// `GuestModule` factory and export surface separately.
 #[macro_export]
 macro_rules! export_wasm_guest {
     (
         factory: $factory:path
         $(, lifecycle: [$($lifecycle:ident),* $(,)?])?
         $(, actions: $actions:tt)?
+        $(, server_messages: $server_messages:tt)?
         $(,)?
     ) => {
         #[unsafe(no_mangle)]
@@ -579,7 +764,8 @@ macro_rules! export_wasm_guest {
             $crate::__private::assert_export_surface(
                 &module,
                 $crate::export_wasm_guest!(@lifecycle_struct $($($lifecycle),*)?),
-                $crate::export_wasm_guest!(@actions_bool $($actions)?),
+                $crate::export_wasm_guest!(@bool $($actions)?),
+                $crate::export_wasm_guest!(@bool $($server_messages)?),
             );
             $crate::__private::wasm_guest_negotiate(&module, ptr, len)
         }
@@ -589,6 +775,7 @@ macro_rules! export_wasm_guest {
         $crate::export_wasm_guest!(@maybe_export $factory, tick_client, $($($lifecycle),*)?);
         $crate::export_wasm_guest!(@maybe_export $factory, tick_server, $($($lifecycle),*)?);
         $crate::export_wasm_guest!(@maybe_export_action $factory, $($actions)?);
+        $crate::export_wasm_guest!(@maybe_export_server_messages $factory, $($server_messages)?);
     };
 
     (@lifecycle_struct $($hook:ident),*) => {{
@@ -596,16 +783,9 @@ macro_rules! export_wasm_guest {
         $(hooks.$hook = true;)*
         hooks
     }};
-
-    (@actions_bool true) => {
-        true
-    };
-    (@actions_bool false) => {
-        false
-    };
-    (@actions_bool) => {
-        false
-    };
+    (@bool true) => { true };
+    (@bool false) => { false };
+    (@bool) => { false };
 
     (@maybe_export $factory:path, start_client, start_client $(, $rest:ident)*) => {
         #[unsafe(no_mangle)]
@@ -668,16 +848,26 @@ macro_rules! export_wasm_guest {
     };
     (@maybe_export_action $factory:path, false) => {};
     (@maybe_export_action $factory:path) => {};
+
+    (@maybe_export_server_messages $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_server_messages(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::wasm_guest_server_messages(&module, ptr, len)
+        }
+    };
+    (@maybe_export_server_messages $factory:path,) => {};
+    (@maybe_export_server_messages $factory:path, false) => {};
+    (@maybe_export_server_messages $factory:path) => {};
 }
 
-/// Lower-level native export wiring for cases where you intentionally manage a
-/// `GuestModule` factory and export surface separately.
 #[macro_export]
 macro_rules! export_native_guest {
     (
         factory: $factory:path
         $(, lifecycle: [$($lifecycle:ident),* $(,)?])?
         $(, actions: $actions:tt)?
+        $(, server_messages: $server_messages:tt)?
         $(,)?
     ) => {
         #[unsafe(no_mangle)]
@@ -698,7 +888,8 @@ macro_rules! export_native_guest {
             $crate::__private::assert_export_surface(
                 &module,
                 $crate::export_native_guest!(@lifecycle_struct $($($lifecycle),*)?),
-                $crate::export_native_guest!(@actions_bool $($actions)?),
+                $crate::export_native_guest!(@bool $($actions)?),
+                $crate::export_native_guest!(@bool $($server_messages)?),
             );
             $crate::__private::native_guest_negotiate(&module, input)
         }
@@ -708,6 +899,7 @@ macro_rules! export_native_guest {
         $crate::export_native_guest!(@maybe_export $factory, tick_client, $($($lifecycle),*)?);
         $crate::export_native_guest!(@maybe_export $factory, tick_server, $($($lifecycle),*)?);
         $crate::export_native_guest!(@maybe_export_action $factory, $($actions)?);
+        $crate::export_native_guest!(@maybe_export_server_messages $factory, $($server_messages)?);
     };
 
     (@lifecycle_struct $($hook:ident),*) => {{
@@ -715,16 +907,9 @@ macro_rules! export_native_guest {
         $(hooks.$hook = true;)*
         hooks
     }};
-
-    (@actions_bool true) => {
-        true
-    };
-    (@actions_bool false) => {
-        false
-    };
-    (@actions_bool) => {
-        false
-    };
+    (@bool true) => { true };
+    (@bool false) => { false };
+    (@bool) => { false };
 
     (@maybe_export $factory:path, start_client, start_client $(, $rest:ident)*) => {
         #[unsafe(no_mangle)]
@@ -797,15 +982,28 @@ macro_rules! export_native_guest {
     };
     (@maybe_export_action $factory:path, false) => {};
     (@maybe_export_action $factory:path) => {};
+
+    (@maybe_export_server_messages $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_server_messages(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::native_guest_server_messages(&module, input)
+        }
+    };
+    (@maybe_export_server_messages $factory:path,) => {};
+    (@maybe_export_server_messages $factory:path, false) => {};
+    (@maybe_export_server_messages $factory:path) => {};
 }
 
-/// Defines the canonical guest description and the Wasm export surface from one
-/// declarative source of truth.
 #[macro_export]
 macro_rules! wasm_guest {
     (
         guest_id: $guest_id:expr
+        $(, registration: { $($registration:tt)* })?
         $(, lifecycle: { $($lifecycle:ident : $lifecycle_handler:expr),* $(,)? })?
+        $(, server_messages: $server_messages_handler:expr)?
         $(, actions: {
             $(
                 $action_key:expr => {
@@ -822,7 +1020,9 @@ macro_rules! wasm_guest {
             $crate::wasm_guest!(
                 @module
                 guest_id: $guest_id
+                $(, registration: { $($registration)* })?
                 $(, lifecycle: { $($lifecycle : $lifecycle_handler),* })?
+                $(, server_messages: $server_messages_handler)?
                 $(, actions: {
                     $(
                         $action_key => {
@@ -838,6 +1038,7 @@ macro_rules! wasm_guest {
             @export
             factory: __freven_guest_sdk_module
             $(, lifecycle: [$($lifecycle),*])?
+            $(, server_messages: [$server_messages_handler])?
             $(, actions: [$($action_key),*])?
         );
     };
@@ -845,7 +1046,9 @@ macro_rules! wasm_guest {
     (
         @module
         guest_id: $guest_id:expr
+        $(, registration: { $($registration:tt)* })?
         $(, lifecycle: { $($lifecycle:ident : $lifecycle_handler:expr),* $(,)? })?
+        $(, server_messages: $server_messages_handler:expr)?
         $(, actions: {
             $(
                 $action_key:expr => {
@@ -859,6 +1062,9 @@ macro_rules! wasm_guest {
     ) => {{
         let module = $crate::GuestModule::new($guest_id);
         $(
+            let module = $crate::wasm_guest!(@registration module, $($registration)*);
+        )?
+        $(
             $(
                 let module = $crate::wasm_guest!(
                     @register_lifecycle
@@ -869,6 +1075,9 @@ macro_rules! wasm_guest {
             )*
         )?
         $(
+            let module = module.on_server_messages($server_messages_handler);
+        )?
+        $(
             $(
                 let module = module.action($action_key, $binding_id, $action_handler);
             )*
@@ -876,23 +1085,22 @@ macro_rules! wasm_guest {
         module
     }};
 
-    (@register_lifecycle $module:ident, start_client, $handler:expr) => {
-        $module.on_start_client($handler)
-    };
-    (@register_lifecycle $module:ident, start_server, $handler:expr) => {
-        $module.on_start_server($handler)
-    };
-    (@register_lifecycle $module:ident, tick_client, $handler:expr) => {
-        $module.on_tick_client($handler)
-    };
-    (@register_lifecycle $module:ident, tick_server, $handler:expr) => {
-        $module.on_tick_server($handler)
-    };
+    (@register_lifecycle $module:ident, start_client, $handler:expr) => { $module.on_start_client($handler) };
+    (@register_lifecycle $module:ident, start_server, $handler:expr) => { $module.on_start_server($handler) };
+    (@register_lifecycle $module:ident, tick_client, $handler:expr) => { $module.on_tick_client($handler) };
+    (@register_lifecycle $module:ident, tick_server, $handler:expr) => { $module.on_tick_server($handler) };
 
     (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?) => {
         $crate::export_wasm_guest!(
             factory: $factory
             $(, lifecycle: [$($lifecycle),*])?
+        );
+    };
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, server_messages: [$handler:expr]) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+            , server_messages: true
         );
     };
     (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, actions: []) => {
@@ -908,6 +1116,38 @@ macro_rules! wasm_guest {
             , actions: true
         );
     };
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, server_messages: [$handler:expr], actions: []) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+            , server_messages: true
+        );
+    };
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, server_messages: [$handler:expr], actions: [$first:expr $(, $rest:expr)*]) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+            , actions: true
+            , server_messages: true
+        );
+    };
+
+    (@registration $module:ident,) => { $module };
+    (@registration $module:ident, block: $key:expr => $def:expr $(, $($rest:tt)*)?) => {
+        $crate::wasm_guest!(@registration $module.register_block($key, $def) $(, $($rest)*)?)
+    };
+    (@registration $module:ident, component: $key:expr => $codec:expr $(, $($rest:tt)*)?) => {
+        $crate::wasm_guest!(@registration $module.register_component($key, $codec) $(, $($rest)*)?)
+    };
+    (@registration $module:ident, message: $key:expr => $codec:expr $(, $($rest:tt)*)?) => {
+        $crate::wasm_guest!(@registration $module.register_message($key, $codec) $(, $($rest)*)?)
+    };
+    (@registration $module:ident, channel: $key:expr => $config:expr $(, $($rest:tt)*)?) => {
+        $crate::wasm_guest!(@registration $module.register_channel($key, $config) $(, $($rest)*)?)
+    };
+    (@registration $module:ident, capability: $key:expr $(, $($rest:tt)*)?) => {
+        $crate::wasm_guest!(@registration $module.declare_capability($key) $(, $($rest)*)?)
+    };
 }
 
 #[cfg(test)]
@@ -916,24 +1156,62 @@ mod tests {
 
     fn module() -> GuestModule {
         GuestModule::new("freven.test.guest")
+            .register_block(
+                "freven.test:stone",
+                BlockDef {
+                    is_solid: true,
+                    is_opaque: true,
+                    render_layer: RenderLayer::Opaque,
+                    debug_tint_rgba: 0,
+                    material_id: 7,
+                },
+            )
+            .register_component("freven.test:name", ComponentCodec::RawBytes)
+            .register_message("freven.test:echo", MessageCodec::RawBytes)
+            .register_channel(
+                "freven.test:echo",
+                ChannelConfig {
+                    reliability: ChannelReliability::Reliable,
+                    ordering: ChannelOrdering::Ordered,
+                    direction: ChannelDirection::Bidirectional,
+                    budget: None,
+                },
+            )
+            .declare_capability("max_call_millis")
             .on_start_server(|_| {})
             .on_tick_server(|_| {})
+            .on_server_messages(|ctx| {
+                let Some(msg) = ctx.messages().first() else {
+                    return ServerMessageResponse::default();
+                };
+                ServerMessageResponse::default().send_to(ServerOutboundMessage {
+                    player_id: msg.player_id,
+                    scope: msg.scope,
+                    channel_id: msg.channel_id,
+                    message_id: msg.message_id,
+                    seq: msg.seq,
+                    payload: msg.payload.clone(),
+                })
+            })
             .action("freven.test:place_block", 7, |_| {
                 ActionResponse::applied().set_block((1, 2, 3), 9)
             })
     }
 
     #[test]
-    fn description_reflects_registered_lifecycle_and_actions() {
+    fn description_reflects_registered_families() {
         let description = module().description();
         assert_eq!(description.guest_id, "freven.test.guest");
-        assert!(description.lifecycle.start_server);
-        assert!(description.lifecycle.tick_server);
-        assert!(!description.lifecycle.start_client);
-        assert!(description.action_entrypoint);
-        assert_eq!(description.actions.len(), 1);
-        assert_eq!(description.actions[0].binding_id, 7);
-        assert_eq!(description.actions[0].key, "freven.test:place_block");
+        assert_eq!(description.registration.blocks.len(), 1);
+        assert_eq!(description.registration.components.len(), 1);
+        assert_eq!(description.registration.messages.len(), 1);
+        assert_eq!(description.registration.channels.len(), 1);
+        assert_eq!(description.registration.actions.len(), 1);
+        assert_eq!(description.registration.capabilities.len(), 1);
+        assert!(description.callbacks.lifecycle.start_server);
+        assert!(description.callbacks.lifecycle.tick_server);
+        assert!(description.callbacks.action);
+        assert!(description.callbacks.server_messages);
     }
 
     #[test]
@@ -945,6 +1223,7 @@ mod tests {
             stream_epoch: 3,
             action_seq: 4,
             at_input_seq: 5,
+            player_position_m: Some([1.0, 2.0, 3.0]),
             payload: &[],
         });
 
@@ -953,149 +1232,20 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "guest_id must not be empty")]
-    fn empty_guest_id_is_rejected() {
-        let _ = GuestModule::new("  ");
-    }
-
-    #[test]
-    #[should_panic(expected = "action key must not be empty")]
-    fn empty_action_key_is_rejected() {
-        let _ =
-            GuestModule::new("freven.test.guest").action(" ", 1, |_| ActionResponse::rejected());
-    }
-
-    #[test]
-    #[should_panic(expected = "registered more than once")]
-    fn duplicate_action_key_is_rejected() {
-        let _ = GuestModule::new("freven.test.guest")
-            .action("freven.test:dup", 1, |_| ActionResponse::rejected())
-            .action("freven.test:dup", 2, |_| ActionResponse::rejected());
-    }
-
-    #[test]
-    #[should_panic(expected = "binding id 1 was registered more than once")]
-    fn duplicate_binding_id_is_rejected() {
-        let _ = GuestModule::new("freven.test.guest")
-            .action("freven.test:first", 1, |_| ActionResponse::rejected())
-            .action("freven.test:second", 1, |_| ActionResponse::rejected());
-    }
-
-    #[test]
-    fn export_surface_assertion_matches_description() {
-        let module = module();
-        __private::assert_export_surface(
-            &module,
-            LifecycleHooks {
-                start_server: true,
-                tick_server: true,
-                ..Default::default()
-            },
-            true,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "export lifecycle does not match")]
-    fn export_surface_assertion_rejects_lifecycle_mismatch() {
-        let module = module();
-        __private::assert_export_surface(&module, LifecycleHooks::default(), true);
-    }
-
-    #[test]
-    #[should_panic(expected = "action export does not match")]
-    fn export_surface_assertion_rejects_action_mismatch() {
-        let module = module();
-        __private::assert_export_surface(
-            &module,
-            LifecycleHooks {
-                start_server: true,
-                tick_server: true,
-                ..Default::default()
-            },
-            false,
-        );
-    }
-
-    fn test_start_server(_: &StartInput) {}
-
-    fn test_tick_server(_: &TickInput) {}
-
-    fn test_handle_action(_: ActionContext<'_>) -> ActionResponse {
-        ActionResponse::applied()
-    }
-
-    #[test]
-    fn wasm_guest_macro_module_description_matches_declared_surface() {
-        let module = crate::wasm_guest!(
-            @module
-            guest_id: "freven.test.single_source",
-            lifecycle: {
-                start_server: test_start_server,
-                tick_server: test_tick_server,
-            },
-            actions: {
-                "freven.test:macro_action" => {
-                    binding_id: 11,
-                    handler: test_handle_action,
-                },
-            },
-        );
-
-        assert_eq!(module.guest_id(), "freven.test.single_source");
-        assert_eq!(
-            module.lifecycle_hooks(),
-            LifecycleHooks {
-                start_server: true,
-                tick_server: true,
-                ..Default::default()
-            }
-        );
-
-        let description = module.description();
-        assert!(description.action_entrypoint);
-        assert_eq!(description.actions.len(), 1);
-        assert_eq!(description.actions[0].key, "freven.test:macro_action");
-        assert_eq!(description.actions[0].binding_id, 11);
-    }
-
-    #[test]
-    fn wasm_guest_macro_supports_guests_without_actions() {
-        let module = crate::wasm_guest!(
-            @module
-            guest_id: "freven.test.lifecycle_only",
-            lifecycle: {
-                start_server: test_start_server,
-            },
-            actions: {},
-        );
-
-        let description = module.description();
-        assert!(!description.action_entrypoint);
-        assert!(description.actions.is_empty());
-        assert_eq!(
-            description.lifecycle,
-            LifecycleHooks {
-                start_server: true,
-                ..Default::default()
-            }
-        );
-    }
-
-    #[test]
-    fn native_guest_alloc_dealloc_round_trips_exact_sized_buffer() {
-        let ptr = __private::native_guest_alloc(16);
-        assert!(!ptr.is_null());
-
-        unsafe {
-            core::ptr::write_bytes(ptr, 0xAB, 16);
-        }
-
-        __private::native_guest_dealloc(NativeGuestBuffer { ptr, len: 16 });
-    }
-
-    #[test]
-    fn native_guest_dealloc_accepts_empty_buffer() {
-        __private::native_guest_dealloc(NativeGuestBuffer::empty());
+    fn server_message_handler_round_trips() {
+        let result = module().handle_server_messages(ServerMessageInput {
+            tick: 5,
+            dt_millis: 16,
+            messages: vec![ServerInboundMessage {
+                player_id: 42,
+                scope: MessageScope::Global,
+                channel_id: 1,
+                message_id: 2,
+                seq: Some(3),
+                payload: b"hello".to_vec(),
+            }],
+        });
+        assert_eq!(result.outbound.len(), 1);
+        assert_eq!(result.outbound[0].payload, b"hello");
     }
 }

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -25,7 +25,7 @@ contract meaning defined here.
 
 ## Negotiation
 
-Host and guest negotiate before any lifecycle or action callback.
+Host and guest negotiate before any guest callback.
 
 - `NegotiationRequest`
   - `supported_contract_versions: Vec<u32>`
@@ -39,9 +39,17 @@ Host and guest negotiate before any lifecycle or action callback.
 `GuestDescription` declares:
 
 - `guest_id`
-- `lifecycle: LifecycleHooks`
-- `action_entrypoint`
-- `actions: Vec<ActionBinding>`
+- `registration: GuestRegistration`
+- `callbacks: GuestCallbacks`
+
+`GuestRegistration` currently covers:
+
+- `blocks`
+- `components`
+- `messages`
+- `channels`
+- `actions`
+- `capabilities`
 
 `LifecycleHooks` currently exposes:
 
@@ -58,6 +66,14 @@ Host and guest negotiate before any lifecycle or action callback.
 - Guest returns `ActionResult`
 - `ActionResult.outcome` is `applied` or `rejected`
 - `ActionResult.effects` currently supports world effects through `WorldEffect`
+- `ActionInput.player_position_m` is the first canonical player-read slice
+
+## Server message path
+
+- Host sends `ServerMessageInput`
+- Guest returns `ServerMessageResult`
+- This is a dedicated callback family, separate from actions and lifecycle
+- `ServerMessageResult.outbound` carries `ServerOutboundMessage` sends
 
 ## Lifecycle path
 
@@ -76,7 +92,7 @@ If a guest violates the contract or faults during a runtime session:
 
 - that guest is disabled for the remainder of the runtime session
 - further action dispatches to that guest must reject
-- the host must stop routing later lifecycle callbacks to that guest for that
+- the host must stop routing later lifecycle and message callbacks to that guest for that
   session
 
 For action callbacks, "faults" include host-side failure to apply the guest's

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -60,6 +60,14 @@ Host and guest negotiate before any guest callback.
 
 `on_start_common` is intentionally not part of the guest contract yet.
 
+Registration/callback invariants:
+
+- `registration.actions` and `callbacks.action` are one family:
+  declaring actions requires `callbacks.action = true`
+- `callbacks.action = true` requires at least one declared action
+- capability keys must be non-empty
+- declared capability keys must exist in the resolved host capability table
+
 ## Action path
 
 - Host sends `ActionInput`
@@ -74,6 +82,10 @@ Host and guest negotiate before any guest callback.
 - Guest returns `ServerMessageResult`
 - This is a dedicated callback family, separate from actions and lifecycle
 - `ServerMessageResult.outbound` carries `ServerOutboundMessage` sends
+- host routing is channel/message-contract checked:
+  inbound messages are delivered only for declared server-readable channels and declared message ids
+- outbound sends must use declared message ids and declared server-writable channels
+- unsupported/unknown message scope mapping is a guest fault, not a silent fallback
 
 ## Lifecycle path
 
@@ -97,3 +109,6 @@ If a guest violates the contract or faults during a runtime session:
 
 For action callbacks, "faults" include host-side failure to apply the guest's
 declared world effects after the `ActionResult` is decoded and validated.
+
+For server-message callbacks, faults include invalid inbound scope mapping and
+outbound sends that violate the negotiated channel/message contract.

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -5,7 +5,7 @@ Freven native mods.
 
 The canonical public guest contract is `freven_guest` as documented in
 `GUEST_CONTRACT_v1.md`. Native is a secondary unsafe transport that carries the
-same guest negotiation and action semantics over an in-process native-width ABI.
+same guest negotiation, declaration, and callback semantics over an in-process native-width ABI.
 
 This is not the recommended public authoring path. Prefer Wasm with
 `freven_guest_sdk` unless you are intentionally doing low-level runtime work on
@@ -19,15 +19,17 @@ A native mod dynamic library must export these symbols:
 - `freven_guest_dealloc(buffer: NativeGuestBuffer)`
 - `freven_guest_negotiate(input: NativeGuestInput) -> NativeGuestBuffer`
 - `freven_guest_handle_action(input: NativeGuestInput) -> NativeGuestBuffer` when
-  `action_entrypoint = true`
+  `callbacks.action = true`
+- `freven_guest_on_server_messages(input: NativeGuestInput) -> NativeGuestBuffer`
+  when `callbacks.server_messages = true`
 - `freven_guest_on_start_client(input: NativeGuestInput) -> NativeGuestBuffer`
-  when `lifecycle.start_client = true`
+  when `callbacks.lifecycle.start_client = true`
 - `freven_guest_on_start_server(input: NativeGuestInput) -> NativeGuestBuffer`
-  when `lifecycle.start_server = true`
+  when `callbacks.lifecycle.start_server = true`
 - `freven_guest_on_tick_client(input: NativeGuestInput) -> NativeGuestBuffer`
-  when `lifecycle.tick_client = true`
+  when `callbacks.lifecycle.tick_client = true`
 - `freven_guest_on_tick_server(input: NativeGuestInput) -> NativeGuestBuffer`
-  when `lifecycle.tick_server = true`
+  when `callbacks.lifecycle.tick_server = true`
 
 FFI structs:
 
@@ -70,6 +72,7 @@ Returned bytes are postcard-encoded `freven_guest` contract types:
 
 - `freven_guest_negotiate` takes `NegotiationRequest` and returns `NegotiationResponse`
 - `freven_guest_handle_action` takes `ActionInput` and returns `ActionResult`
+- `freven_guest_on_server_messages` takes `ServerMessageInput` and returns `ServerMessageResult`
 - lifecycle exports take `StartInput` or `TickInput` and return `LifecycleAck`
 
 `ActionInput` carries `binding_id`, `player_id`, `level_id`, `stream_epoch`,
@@ -86,7 +89,7 @@ Runtime validates and enforces:
 - no duplicate action keys within one guest description
 - no duplicate `binding_id` values within one guest description
 - max byte caps for negotiation/result/input payload before copying
-- declared action/lifecycle surface exactly matches the exported symbol surface
+- declared callback surface exactly matches the exported symbol surface
 - dual-side lifecycle declarations are allowed; the runtime hosts the active side as a subset for the current session
 
 On decode/validation/contract errors, attach fails.

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -88,12 +88,16 @@ Runtime validates and enforces:
 - non-empty action keys
 - no duplicate action keys within one guest description
 - no duplicate `binding_id` values within one guest description
+- declared actions require `callbacks.action = true`
+- `callbacks.action = true` requires at least one declared action
 - max byte caps for negotiation/result/input payload before copying
 - declared callback surface exactly matches the exported symbol surface
 - dual-side lifecycle declarations are allowed; the runtime hosts the active side as a subset for the current session
+- server-message routing uses the negotiated registration contract:
+  inbound delivery only for declared server-readable channels, outbound sends only for declared server-writable channels and declared message ids
 
 On decode/validation/contract errors, attach fails.
-On lifecycle or action-call faults, runtime disables that guest mod for the
+On lifecycle, action-call, or server-message contract faults, runtime disables that guest mod for the
 current runtime session and later lifecycle/action calls reject. That includes
 host-side failure to apply guest-declared world effects after a valid
 `ActionResult` returns.

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -12,7 +12,7 @@ recommended getting-started path.
 
 ## Scope
 
-- Supports negotiation, lifecycle callbacks, and action handling over Wasm
+- Supports negotiation, declaration registration, lifecycle callbacks, server-message callbacks, and action handling over Wasm
   ptr/len calls.
 - Host runs modules with no WASI and no host imports by default.
 - `[capabilities]` in `mod.toml` is enforced by runtime with a strict allowlist.
@@ -24,7 +24,8 @@ A module must export these symbols:
 - `freven_guest_alloc(size: u32) -> u32`
 - `freven_guest_dealloc(ptr: u32, size: u32)`
 - `freven_guest_negotiate(ptr: u32, len: u32) -> u64`
-- `freven_guest_handle_action(ptr: u32, len: u32) -> u64` if `action_entrypoint = true`
+- `freven_guest_handle_action(ptr: u32, len: u32) -> u64` if `callbacks.action = true`
+- `freven_guest_on_server_messages(ptr: u32, len: u32) -> u64` if `callbacks.server_messages = true`
 - linear memory export named `memory`
 
 Optional lifecycle exports:
@@ -55,9 +56,9 @@ Output: `NegotiationResponse`
 Host behavior:
 
 - validates `selected_contract_version`
-- validates `GuestDescription` against exported Wasm symbols
-- registers each `actions[].key` as runtime action kind
-- maps runtime action kind to `actions[].binding_id` for callback dispatch
+- validates `GuestDescription.callbacks` against exported Wasm symbols
+- registers `GuestDescription.registration` into the canonical host runtime
+- maps runtime action kind to `registration.actions[].binding_id` for callback dispatch
 
 ### Lifecycle inputs and outputs
 
@@ -78,7 +79,14 @@ lifecycle effect payload is not part of the contract.
 - `stream_epoch: u32`
 - `action_seq: u32`
 - `at_input_seq: u32`
+- `player_position_m: Option<[f32; 3]>`
 - `payload: &[u8]` (opaque client/server action payload)
+
+### Server message callback
+
+- `freven_guest_on_server_messages` input: `ServerMessageInput`
+- output: `ServerMessageResult`
+- the host routes inbound server-side mod messages for the guest's registered channels into this callback
 
 ### Action result (`freven_guest_handle_action` return bytes)
 

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -28,6 +28,11 @@ A module must export these symbols:
 - `freven_guest_on_server_messages(ptr: u32, len: u32) -> u64` if `callbacks.server_messages = true`
 - linear memory export named `memory`
 
+The negotiated `GuestDescription` must also be internally coherent:
+
+- declared actions require `callbacks.action = true`
+- `callbacks.action = true` requires at least one declared action
+
 Optional lifecycle exports:
 
 - `freven_guest_on_start_client(ptr: u32, len: u32) -> u64`
@@ -86,7 +91,9 @@ lifecycle effect payload is not part of the contract.
 
 - `freven_guest_on_server_messages` input: `ServerMessageInput`
 - output: `ServerMessageResult`
-- the host routes inbound server-side mod messages for the guest's registered channels into this callback
+- the host routes inbound server-side mod messages only for the guest's declared server-readable channels
+- guest outbound sends must use declared message ids and declared server-writable channels
+- unsupported message-scope mapping is rejected explicitly; the runtime does not silently coerce scope
 
 ### Action result (`freven_guest_handle_action` return bytes)
 
@@ -120,6 +127,8 @@ Runtime accepts only these capability keys:
 - `allow_unstable` (boolean, must be `false`)
 
 Unknown keys are rejected. Invalid types are rejected.
+Declared capability keys must also exist in the resolved capability table; the
+runtime reports that as an explicit capability-declaration error rather than a duplicate-key error.
 
 Current host policy maxima/defaults:
 


### PR DESCRIPTION
## Summary
This PR expands the public `freven_guest` / `freven_guest_sdk` contract from a lifecycle+action surface into a fuller transport-neutral model built around canonical registration families and callback families.

It adds first-class declarations for blocks, components, messages, channels, actions, and capabilities; introduces dedicated server-message callbacks and payload types; includes `player_position_m` in action input; and updates the SDK builders/macros/docs so Wasm/native guests describe one coherent contract surface.

It also adds explicit, honest validation semantics around empty keys, undeclared capabilities, and invalid declaration-family combinations such as `registration.actions` without `callbacks.action` (and vice versa), plus extra SDK coverage for macro wiring and export-surface invariants.

## Validation
List what you ran:
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo test --workspace --all-features

## freven-sdk dependency
- Does this PR change the pinned `freven-sdk` tag?
  - [x] No
  - [ ] Yes (which tag and why?)

## Notes for reviewers
Please double-check:
- the new registration/callback split in `GuestDescription`
- `wasm_guest!` macro registration recursion after the shape fix
- export-surface assertions for action/server-message callbacks
- doc wording around contract invariants vs transport-specific ABI details