### PR TITLE
Phase 01: canonical activation plan and single load truth

### DIFF
--- a/crates/freven_api/README.md
+++ b/crates/freven_api/README.md
@@ -6,6 +6,9 @@ Stable SDK contracts for Freven experiences and compile-time mods.
 experiences and compile-time mods. It is intended to stay stable so mods can be
 built and versioned independently from engine internals.
 
+`ExperienceSpec` in this crate is a compile-time convenience surface. Canonical
+boot/load/runtime truth lives in the engine runtime activation model, not here.
+
 The lifecycle contract is intentionally small:
 - registration via `ModContext`
 - activation via `on_start_common`, `on_start_client`, `on_start_server`

--- a/crates/freven_api/src/lib.rs
+++ b/crates/freven_api/src/lib.rs
@@ -144,7 +144,7 @@ impl ModSide {
     }
 }
 
-/// Experience specification selected by boot.
+/// Compile-time convenience experience specification.
 ///
 /// `config` is a top-level table keyed by mod id. Each mod receives its own value.
 #[derive(Clone)]
@@ -153,6 +153,7 @@ pub struct ExperienceSpec {
     pub mods: Vec<ModDescriptor>,
     pub default_worldgen: Option<String>,
     pub default_character_controller: Option<String>,
+    pub default_client_control_provider: Option<String>,
     pub config: toml::Table,
 }
 
@@ -215,7 +216,6 @@ pub trait ModContextBackend {
         handler: Box<dyn ActionHandler>,
     ) -> Result<(), ModRegistrationError>;
     fn register_action_kind(&mut self, key: &str) -> Result<ActionKindId, ModRegistrationError>;
-    fn set_should_load(&mut self, hook: ShouldLoadHook);
     fn on_start_common(&mut self, hook: StartCommonHook);
     fn on_start_client(&mut self, hook: StartClientHook);
     fn on_start_server(&mut self, hook: StartServerHook);
@@ -359,10 +359,6 @@ impl<'a> ModContext<'a> {
         self.backend.register_action_kind(key)
     }
 
-    pub fn set_should_load(&mut self, hook: ShouldLoadHook) {
-        self.backend.set_should_load(hook);
-    }
-
     pub fn on_start_common(&mut self, hook: StartCommonHook) {
         self.backend.on_start_common(hook);
     }
@@ -495,9 +491,6 @@ pub enum ModConfigError {
         source: toml::de::Error,
     },
 }
-
-/// Lifecycle predicate used to decide if a mod should load for the runtime side.
-pub type ShouldLoadHook = fn(Side) -> bool;
 
 /// Lifecycle callback executed once for both sides when the mod starts.
 pub type StartCommonHook = for<'a> fn(&mut CommonApi<'a>);


### PR DESCRIPTION
- introduce RuntimeActivationPlan
- remove runtime should_load re-gating
- replace lossy builtin-only ExperienceSpec boot bridge
- thread defaults/config through activation truth
- keep ExperienceSpec only as compile-time helper