### PR TITLE
Unify and broaden the public guest contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "freven_api"
 version = "0.1.0"
 dependencies = [
+ "freven_guest",
  "freven_sdk_types",
  "serde",
  "thiserror",
@@ -55,6 +56,7 @@ dependencies = [
  "freven_sdk_types",
  "postcard",
  "serde",
+ "toml",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The **engine source is private** and is **not** part of this repository.
 ## Public surface (GitHub-first)
 
 Current SDK crates:
-- `freven_api` - stable-ish SDK contracts (pre-1.0)
+- `freven_api` - compile-time facade over the canonical public declaration model
 - `freven_guest` - canonical transport-agnostic guest contract for runtime-loaded mods
 - `freven_guest_sdk` - high-level guest authoring SDK for the normal Wasm mod path
 - `freven_sdk_types` - pure shared SDK types
@@ -37,6 +37,9 @@ See [docs/SDK_DISTRIBUTION.md](docs/SDK_DISTRIBUTION.md) for the rollout plan an
 - Start with [docs/WASM_AUTHORING.md](docs/WASM_AUTHORING.md).
 - Use `freven_guest_sdk` for normal mod authoring.
 - Treat `freven_guest` and the transport ABI docs as reference material for low-level tests, fixtures, and runtime work.
+- Treat `freven_api` and `freven_guest` as two facades over one declaration
+  model by breadth; runtime guest execution still policy-gates provider-family
+  hosting where services do not exist yet.
 - Prefer Wasm for the primary safe path.
 - Treat native and external transports as secondary integrations with narrower maturity/safety guarantees.
 

--- a/crates/freven_api/Cargo.toml
+++ b/crates/freven_api/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 publish = false
 
 [dependencies]
+freven_guest.workspace = true
 freven_sdk_types.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/freven_api/README.md
+++ b/crates/freven_api/README.md
@@ -11,8 +11,8 @@ boot/load/runtime truth lives in the engine runtime activation model, not here.
 
 The lifecycle contract is intentionally small:
 - registration via `ModContext`
-- activation via `on_start_common`, `on_start_client`, `on_start_server`
-- runtime via `on_tick_client`, `on_tick_server`, and explicit action dispatch
+- activation via `on_start_client`, `on_start_server`
+- runtime via `on_tick_client`, `on_tick_server`, explicit action dispatch, and dedicated `on_client_messages` / `on_server_messages` phases
 
 Engine/app/bootstrap wiring does not belong in this crate.
 

--- a/crates/freven_api/README.md
+++ b/crates/freven_api/README.md
@@ -19,6 +19,12 @@ Engine/app/bootstrap wiring does not belong in this crate.
 For runtime-loaded guests, the canonical public contract lives in
 `freven_guest`, not in transport-specific ABI docs.
 
+`freven_api` is the compile-time facade over that same canonical declaration
+model by breadth. Provider families such as worldgen, character controllers,
+and client control providers are no longer compile-time-only secret semantics;
+they exist canonically in `freven_guest` even when a runtime guest execution
+policy still gates hosting for them.
+
 ## Stability and semver stance
 
 - Public runtime/mod contracts are treated as stable API.

--- a/crates/freven_api/src/lib.rs
+++ b/crates/freven_api/src/lib.rs
@@ -216,11 +216,12 @@ pub trait ModContextBackend {
         handler: Box<dyn ActionHandler>,
     ) -> Result<(), ModRegistrationError>;
     fn register_action_kind(&mut self, key: &str) -> Result<ActionKindId, ModRegistrationError>;
-    fn on_start_common(&mut self, hook: StartCommonHook);
     fn on_start_client(&mut self, hook: StartClientHook);
     fn on_start_server(&mut self, hook: StartServerHook);
     fn on_tick_client(&mut self, hook: TickClientHook);
     fn on_tick_server(&mut self, hook: TickServerHook);
+    fn on_client_messages(&mut self, hook: ClientMessagesHook);
+    fn on_server_messages(&mut self, hook: ServerMessagesHook);
 }
 
 /// Stable SDK-facing registration context passed to mods.
@@ -359,10 +360,6 @@ impl<'a> ModContext<'a> {
         self.backend.register_action_kind(key)
     }
 
-    pub fn on_start_common(&mut self, hook: StartCommonHook) {
-        self.backend.on_start_common(hook);
-    }
-
     pub fn on_start_client(&mut self, hook: StartClientHook) {
         self.backend.on_start_client(hook);
     }
@@ -377,6 +374,14 @@ impl<'a> ModContext<'a> {
 
     pub fn on_tick_server(&mut self, hook: TickServerHook) {
         self.backend.on_tick_server(hook);
+    }
+
+    pub fn on_client_messages(&mut self, hook: ClientMessagesHook) {
+        self.backend.on_client_messages(hook);
+    }
+
+    pub fn on_server_messages(&mut self, hook: ServerMessagesHook) {
+        self.backend.on_server_messages(hook);
     }
 }
 
@@ -492,9 +497,6 @@ pub enum ModConfigError {
     },
 }
 
-/// Lifecycle callback executed once for both sides when the mod starts.
-pub type StartCommonHook = for<'a> fn(&mut CommonApi<'a>);
-
 /// Lifecycle callback executed once when the client side starts.
 pub type StartClientHook = for<'a> fn(&mut ClientApi<'a>);
 
@@ -506,6 +508,12 @@ pub type TickClientHook = for<'a> fn(&mut ClientTickApi<'a>);
 
 /// Lifecycle callback executed on each server tick.
 pub type TickServerHook = for<'a> fn(&mut ServerTickApi<'a>);
+
+/// Message callback executed on each client message dispatch phase.
+pub type ClientMessagesHook = for<'a> fn(&mut ClientMessagesApi<'a>);
+
+/// Message callback executed on each server message dispatch phase.
+pub type ServerMessagesHook = for<'a> fn(&mut ServerMessagesApi<'a>);
 
 /// Runtime-provided services exposed to SDK hooks.
 pub trait Services {}
@@ -825,6 +833,42 @@ pub trait ServerMessageProvider {
     fn poll_msg(&mut self) -> Option<ServerInboundMessage>;
 }
 
+/// Engine-provided client message send surface.
+pub trait ClientMessageSender {
+    fn send_msg(&mut self, msg: ClientOutboundMessage) -> Result<(), ClientMessageSendError>;
+}
+
+impl<T> ClientMessageSender for T
+where
+    T: ClientMessageProvider + ?Sized,
+{
+    fn send_msg(&mut self, msg: ClientOutboundMessage) -> Result<(), ClientMessageSendError> {
+        ClientMessageProvider::send_msg(self, msg)
+    }
+}
+
+/// Engine-provided server message send surface.
+pub trait ServerMessageSender {
+    fn send_to(
+        &mut self,
+        player_id: u64,
+        msg: ServerOutboundMessage,
+    ) -> Result<(), ServerMessageSendError>;
+}
+
+impl<T> ServerMessageSender for T
+where
+    T: ServerMessageProvider + ?Sized,
+{
+    fn send_to(
+        &mut self,
+        player_id: u64,
+        msg: ServerOutboundMessage,
+    ) -> Result<(), ServerMessageSendError> {
+        ServerMessageProvider::send_to(self, player_id, msg)
+    }
+}
+
 /// Engine-provided player presentation query surface.
 pub trait ClientPlayerProvider {
     fn list_players(&self, out: &mut Vec<ClientPlayerView>);
@@ -839,31 +883,15 @@ pub trait ClientNameplateProvider {
     fn push_nameplate(&mut self, cmd: ClientNameplateDrawCmd);
 }
 
-/// Common side-independent lifecycle API.
-pub struct CommonApi<'a> {
-    pub services: &'a mut dyn Services,
-}
-
-impl<'a> CommonApi<'a> {
-    #[must_use]
-    pub fn new(services: &'a mut dyn Services) -> Self {
-        Self { services }
-    }
-}
-
 /// Server-side lifecycle API.
 pub struct ServerApi<'a> {
     pub services: &'a mut dyn Services,
-    pub messages: &'a mut dyn ServerMessageProvider,
 }
 
 impl<'a> ServerApi<'a> {
     #[must_use]
-    pub fn new(
-        services: &'a mut dyn Services,
-        messages: &'a mut dyn ServerMessageProvider,
-    ) -> Self {
-        Self { services, messages }
+    pub fn new(services: &'a mut dyn Services) -> Self {
+        Self { services }
     }
 }
 
@@ -873,7 +901,6 @@ pub struct ClientApi<'a> {
     pub input: &'a mut dyn ClientInputProvider,
     pub camera: &'a mut dyn ClientCameraHitProvider,
     pub interaction: &'a mut dyn ClientInteractionProvider,
-    pub messages: &'a mut dyn ClientMessageProvider,
     pub players: &'a mut dyn ClientPlayerProvider,
     pub nameplates: &'a mut dyn ClientNameplateProvider,
 }
@@ -885,7 +912,6 @@ impl<'a> ClientApi<'a> {
         input: &'a mut dyn ClientInputProvider,
         camera: &'a mut dyn ClientCameraHitProvider,
         interaction: &'a mut dyn ClientInteractionProvider,
-        messages: &'a mut dyn ClientMessageProvider,
         players: &'a mut dyn ClientPlayerProvider,
         nameplates: &'a mut dyn ClientNameplateProvider,
     ) -> Self {
@@ -894,7 +920,6 @@ impl<'a> ClientApi<'a> {
             input,
             camera,
             interaction,
-            messages,
             players,
             nameplates,
         }
@@ -907,9 +932,58 @@ impl<'a> ClientApi<'a> {
             input: self.input,
             camera: self.camera,
             interaction: self.interaction,
-            messages: self.messages,
             players: self.players,
             nameplates: self.nameplates,
+        }
+    }
+}
+
+/// Client-side message dispatch context.
+pub struct ClientMessagesApi<'a> {
+    pub tick: u64,
+    pub dt: Duration,
+    pub inbound: &'a [ClientInboundMessage],
+    pub sender: &'a mut dyn ClientMessageSender,
+}
+
+impl<'a> ClientMessagesApi<'a> {
+    #[must_use]
+    pub fn new(
+        tick: u64,
+        dt: Duration,
+        inbound: &'a [ClientInboundMessage],
+        sender: &'a mut dyn ClientMessageSender,
+    ) -> Self {
+        Self {
+            tick,
+            dt,
+            inbound,
+            sender,
+        }
+    }
+}
+
+/// Server-side message dispatch context.
+pub struct ServerMessagesApi<'a> {
+    pub tick: u64,
+    pub dt: Duration,
+    pub inbound: &'a [ServerInboundMessage],
+    pub sender: &'a mut dyn ServerMessageSender,
+}
+
+impl<'a> ServerMessagesApi<'a> {
+    #[must_use]
+    pub fn new(
+        tick: u64,
+        dt: Duration,
+        inbound: &'a [ServerInboundMessage],
+        sender: &'a mut dyn ServerMessageSender,
+    ) -> Self {
+        Self {
+            tick,
+            dt,
+            inbound,
+            sender,
         }
     }
 }

--- a/crates/freven_api/src/lib.rs
+++ b/crates/freven_api/src/lib.rs
@@ -4,6 +4,7 @@
 //! - define experience/mod descriptors used by boot/runtime layers
 //! - expose deterministic registration surfaces (components/messages/worldgen/modnet)
 //! - define stable hook contexts and registration errors
+//! - act as the compile-time facade over the canonical declaration model exposed by `freven_guest`
 //!
 //! Extension guidance:
 //! - add new registries behind stable string keys
@@ -14,6 +15,13 @@ use std::{sync::Arc, time::Duration};
 
 use serde::de::DeserializeOwned;
 
+pub use freven_guest::{
+    CharacterControllerDeclaration, ClientControlProviderDeclaration,
+    GuestCallbacks as ModCallbackModel, GuestRegistration as ModDeclarationModel,
+    LifecycleHooks as LifecycleCallbackModel, MessageHooks as MessageCallbackModel,
+    ModConfigDocument as GuestModConfigDocument, ModConfigFormat as GuestModConfigFormat,
+    WorldGenDeclaration,
+};
 pub use freven_sdk_types::blocks::{BlockDef, BlockRuntimeId, RenderLayer};
 pub use freven_sdk_types::{blocks, voxel};
 

--- a/crates/freven_guest/src/lib.rs
+++ b/crates/freven_guest/src/lib.rs
@@ -88,7 +88,7 @@ pub struct GuestRegistration {
 pub struct GuestCallbacks {
     pub lifecycle: LifecycleHooks,
     pub action: bool,
-    pub server_messages: bool,
+    pub messages: MessageHooks,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -97,6 +97,12 @@ pub struct LifecycleHooks {
     pub start_server: bool,
     pub tick_client: bool,
     pub tick_server: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageHooks {
+    pub client: bool,
+    pub server: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -205,6 +211,13 @@ pub struct ActionInput<'a> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientMessageInput {
+    pub tick: u64,
+    pub dt_millis: u32,
+    pub messages: Vec<ClientInboundMessage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServerMessageInput {
     pub tick: u64,
     pub dt_millis: u32,
@@ -218,6 +231,12 @@ pub struct LifecycleAck {}
 pub struct ActionResult {
     pub outcome: ActionOutcome,
     pub effects: EffectBatch,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ClientMessageResult {
+    pub outbound: Vec<ClientOutboundMessage>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -252,6 +271,24 @@ pub enum WorldEffect {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientOutboundMessage {
+    pub scope: ClientOutboundMessageScope,
+    pub channel_id: u32,
+    pub message_id: u32,
+    pub seq: Option<u32>,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientInboundMessage {
+    pub scope: MessageScope,
+    pub channel_id: u32,
+    pub message_id: u32,
+    pub seq: Option<u32>,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServerOutboundMessage {
     pub player_id: u64,
     pub scope: MessageScope,
@@ -276,4 +313,11 @@ pub struct ServerInboundMessage {
 pub enum MessageScope {
     Global,
     Level { level_id: u32, stream_epoch: u32 },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientOutboundMessageScope {
+    Global,
+    ActiveLevel,
 }

--- a/crates/freven_guest/src/lib.rs
+++ b/crates/freven_guest/src/lib.rs
@@ -79,6 +79,9 @@ pub struct GuestRegistration {
     pub blocks: Vec<BlockDeclaration>,
     pub components: Vec<ComponentDeclaration>,
     pub messages: Vec<MessageDeclaration>,
+    pub worldgen: Vec<WorldGenDeclaration>,
+    pub character_controllers: Vec<CharacterControllerDeclaration>,
+    pub client_control_providers: Vec<ClientControlProviderDeclaration>,
     pub channels: Vec<ChannelDeclaration>,
     pub actions: Vec<ActionDeclaration>,
     pub capabilities: Vec<CapabilityDeclaration>,
@@ -127,6 +130,21 @@ pub enum ComponentCodec {
 pub struct MessageDeclaration {
     pub key: String,
     pub codec: MessageCodec,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorldGenDeclaration {
+    pub key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CharacterControllerDeclaration {
+    pub key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientControlProviderDeclaration {
+    pub key: String,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -188,8 +206,27 @@ pub struct CapabilityDeclaration {
     pub key: String,
 }
 
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModConfigFormat {
+    #[default]
+    Toml,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct StartInput {}
+#[serde(default)]
+pub struct ModConfigDocument {
+    pub format: ModConfigFormat,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct StartInput {
+    pub experience_id: String,
+    pub mod_id: String,
+    pub config: ModConfigDocument,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TickInput {

--- a/crates/freven_guest_sdk/Cargo.toml
+++ b/crates/freven_guest_sdk/Cargo.toml
@@ -10,3 +10,4 @@ freven_guest.workspace = true
 freven_sdk_types.workspace = true
 postcard.workspace = true
 serde.workspace = true
+toml.workspace = true

--- a/crates/freven_guest_sdk/README.md
+++ b/crates/freven_guest_sdk/README.md
@@ -10,7 +10,7 @@ canonical `freven_guest` contract and hides the transport boilerplate:
 - Wasm export table wiring
 - native in-process export wiring for low-level fixtures/tests
 - canonical declaration builders for blocks/components/messages/channels/actions/capabilities
-- lifecycle/action/server-message dispatch lookup
+- lifecycle/action/message dispatch lookup
 - export-surface validation against the canonical `GuestDescription`
 
 Most mod authors should depend on `freven_guest_sdk`. Reach for
@@ -64,9 +64,9 @@ intentionally need to wire the raw surface yourself.
   empty or malformed action payload bytes are not silently synthesized by the
   SDK. On the runtime path, that becomes a contract / transport / host-delivery
   fault for the guest call rather than a fabricated placeholder input.
-- Server-side runtime messaging is now a dedicated callback family
-  (`on_server_messages`) rather than being stuffed into actions.
-- Runtime delivery of server messages is contract-checked symmetrically:
+- Runtime messaging is a dedicated callback family on both sides
+  (`on_client_messages`, `on_server_messages`) rather than being stuffed into lifecycle or actions.
+- Runtime delivery is contract-checked symmetrically:
   undeclared inbound channels/message ids fault the guest the same way undeclared outbound use does.
 - Declarations now cover blocks, components, messages, channels, actions, and
   capability keys in one transport-neutral registration model.

--- a/crates/freven_guest_sdk/README.md
+++ b/crates/freven_guest_sdk/README.md
@@ -9,7 +9,7 @@ canonical `freven_guest` contract and hides the transport boilerplate:
 - `postcard` encode/decode plumbing
 - Wasm export table wiring
 - native in-process export wiring for low-level fixtures/tests
-- canonical declaration builders for blocks/components/messages/channels/actions/capabilities
+- canonical declaration builders for blocks/components/messages/worldgen/character-controllers/client-control-providers/channels/actions/capabilities
 - lifecycle/action/message dispatch lookup
 - export-surface validation against the canonical `GuestDescription`
 
@@ -68,10 +68,17 @@ intentionally need to wire the raw surface yourself.
   (`on_client_messages`, `on_server_messages`) rather than being stuffed into lifecycle or actions.
 - Runtime delivery is contract-checked symmetrically:
   undeclared inbound channels/message ids fault the guest the same way undeclared outbound use does.
-- Declarations now cover blocks, components, messages, channels, actions, and
+- Declarations now cover blocks, components, messages, worldgen,
+  character-controllers, client-control-providers, channels, actions, and
   capability keys in one transport-neutral registration model.
+- Guest start callbacks receive `StartInput { experience_id, mod_id, config }`.
+  `StartInputExt::config_typed::<T>()` decodes the canonical per-mod TOML
+  config document for the guest path.
 - Capability declarations are validated honestly by the runtime:
   empty keys fail, and unknown capability keys are rejected against host policy.
+- Provider families are declared honestly but remain runtime-policy-gated for
+  guest transports today: guests can declare those keys, and the host will
+  reject them explicitly until provider hosting exists.
 - Guest-side persistent instance state is not modeled by the SDK today. Use
   explicit statics only when you fully control the implications.
 - Wasm is the primary safe path. Native and external transports remain

--- a/crates/freven_guest_sdk/src/lib.rs
+++ b/crates/freven_guest_sdk/src/lib.rs
@@ -7,13 +7,15 @@ use alloc::vec::Vec;
 pub use freven_guest::{
     ActionDeclaration, ActionInput, ActionOutcome, ActionResult, BlockDeclaration,
     CapabilityDeclaration, ChannelBudget, ChannelConfig, ChannelDeclaration, ChannelDirection,
-    ChannelOrdering, ChannelReliability, ClientInboundMessage, ClientMessageInput,
+    ChannelOrdering, ChannelReliability, CharacterControllerDeclaration,
+    ClientControlProviderDeclaration, ClientInboundMessage, ClientMessageInput,
     ClientMessageResult, ClientOutboundMessage, ClientOutboundMessageScope, ComponentCodec,
     ComponentDeclaration, EffectBatch, GUEST_CONTRACT_VERSION_1, GuestCallbacks, GuestDescription,
     GuestRegistration, GuestTransport, LifecycleAck, LifecycleHooks, MessageCodec,
-    MessageDeclaration, MessageHooks, MessageScope, NativeGuestBuffer, NativeGuestInput,
-    NegotiationRequest, NegotiationResponse, ServerInboundMessage, ServerMessageInput,
-    ServerMessageResult, ServerOutboundMessage, StartInput, TickInput, WorldEffect,
+    MessageDeclaration, MessageHooks, MessageScope, ModConfigDocument, ModConfigFormat,
+    NativeGuestBuffer, NativeGuestInput, NegotiationRequest, NegotiationResponse,
+    ServerInboundMessage, ServerMessageInput, ServerMessageResult, ServerOutboundMessage,
+    StartInput, TickInput, WorldEffect, WorldGenDeclaration,
 };
 pub use freven_sdk_types::blocks::{BlockDef, RenderLayer};
 use serde::de::DeserializeOwned;
@@ -29,6 +31,9 @@ pub struct GuestModule {
     blocks: Vec<BlockDeclaration>,
     components: Vec<ComponentDeclaration>,
     messages: Vec<MessageDeclaration>,
+    worldgen: Vec<WorldGenDeclaration>,
+    character_controllers: Vec<CharacterControllerDeclaration>,
+    client_control_providers: Vec<ClientControlProviderDeclaration>,
     channels: Vec<ChannelDeclaration>,
     actions: Vec<GuestAction>,
     capabilities: Vec<CapabilityDeclaration>,
@@ -52,6 +57,9 @@ impl GuestModule {
             blocks: Vec::new(),
             components: Vec::new(),
             messages: Vec::new(),
+            worldgen: Vec::new(),
+            character_controllers: Vec::new(),
+            client_control_providers: Vec::new(),
             channels: Vec::new(),
             actions: Vec::new(),
             capabilities: Vec::new(),
@@ -103,6 +111,51 @@ impl GuestModule {
             key: key.to_string(),
             codec,
         });
+        self
+    }
+
+    #[must_use]
+    pub fn register_worldgen(mut self, key: &'static str) -> Self {
+        assert_unique_key(
+            "worldgen",
+            key,
+            self.worldgen.iter().map(|entry| entry.key.as_str()),
+        );
+        self.worldgen.push(WorldGenDeclaration {
+            key: key.to_string(),
+        });
+        self
+    }
+
+    #[must_use]
+    pub fn register_character_controller(mut self, key: &'static str) -> Self {
+        assert_unique_key(
+            "character_controller",
+            key,
+            self.character_controllers
+                .iter()
+                .map(|entry| entry.key.as_str()),
+        );
+        self.character_controllers
+            .push(CharacterControllerDeclaration {
+                key: key.to_string(),
+            });
+        self
+    }
+
+    #[must_use]
+    pub fn register_client_control_provider(mut self, key: &'static str) -> Self {
+        assert_unique_key(
+            "client_control_provider",
+            key,
+            self.client_control_providers
+                .iter()
+                .map(|entry| entry.key.as_str()),
+        );
+        self.client_control_providers
+            .push(ClientControlProviderDeclaration {
+                key: key.to_string(),
+            });
         self
     }
 
@@ -221,6 +274,9 @@ impl GuestModule {
                 blocks: self.blocks.clone(),
                 components: self.components.clone(),
                 messages: self.messages.clone(),
+                worldgen: self.worldgen.clone(),
+                character_controllers: self.character_controllers.clone(),
+                client_control_providers: self.client_control_providers.clone(),
                 channels: self.channels.clone(),
                 actions: self
                     .actions
@@ -362,6 +418,28 @@ impl<'a> ActionContext<'a> {
         T: DeserializeOwned,
     {
         postcard::from_bytes(self.input.payload)
+    }
+}
+
+pub trait StartInputExt {
+    fn config_text(&self) -> &str;
+    fn config_typed<T>(&self) -> Result<T, toml::de::Error>
+    where
+        T: DeserializeOwned;
+}
+
+impl StartInputExt for StartInput {
+    fn config_text(&self) -> &str {
+        &self.config.text
+    }
+
+    fn config_typed<T>(&self) -> Result<T, toml::de::Error>
+    where
+        T: DeserializeOwned,
+    {
+        match self.config.format {
+            ModConfigFormat::Toml => toml::from_str(&self.config.text),
+        }
     }
 }
 
@@ -1313,6 +1391,15 @@ macro_rules! wasm_guest {
     (@registration $module:expr, message: $key:expr => $codec:expr $(, $($rest:tt)*)?) => {
         $crate::wasm_guest!(@registration $module.register_message($key, $codec) $(, $($rest)*)?)
     };
+    (@registration $module:expr, worldgen: $key:expr $(, $($rest:tt)*)?) => {
+        $crate::wasm_guest!(@registration $module.register_worldgen($key) $(, $($rest)*)?)
+    };
+    (@registration $module:expr, character_controller: $key:expr $(, $($rest:tt)*)?) => {
+        $crate::wasm_guest!(@registration $module.register_character_controller($key) $(, $($rest)*)?)
+    };
+    (@registration $module:expr, client_control_provider: $key:expr $(, $($rest:tt)*)?) => {
+        $crate::wasm_guest!(@registration $module.register_client_control_provider($key) $(, $($rest)*)?)
+    };
     (@registration $module:expr, channel: $key:expr => $config:expr $(, $($rest:tt)*)?) => {
         $crate::wasm_guest!(@registration $module.register_channel($key, $config) $(, $($rest)*)?)
     };
@@ -1348,6 +1435,9 @@ mod tests {
             )
             .register_component("freven.test:name", ComponentCodec::RawBytes)
             .register_message("freven.test:echo", MessageCodec::RawBytes)
+            .register_worldgen("freven.test:flat")
+            .register_character_controller("freven.test:humanoid")
+            .register_client_control_provider("freven.test:controls")
             .register_channel("freven.test:echo", message_channel())
             .declare_capability("max_call_millis")
             .on_start_server(|_| {})
@@ -1383,6 +1473,9 @@ mod tests {
         assert_eq!(description.registration.blocks.len(), 1);
         assert_eq!(description.registration.components.len(), 1);
         assert_eq!(description.registration.messages.len(), 1);
+        assert_eq!(description.registration.worldgen.len(), 1);
+        assert_eq!(description.registration.character_controllers.len(), 1);
+        assert_eq!(description.registration.client_control_providers.len(), 1);
         assert_eq!(description.registration.channels.len(), 1);
         assert_eq!(description.registration.actions.len(), 1);
         assert_eq!(description.registration.capabilities.len(), 1);
@@ -1390,6 +1483,29 @@ mod tests {
         assert!(description.callbacks.lifecycle.tick_server);
         assert!(description.callbacks.action);
         assert!(description.callbacks.messages.server);
+    }
+
+    #[test]
+    fn start_input_ext_decodes_toml_config() {
+        #[derive(serde::Deserialize)]
+        struct TestConfig {
+            motd: String,
+        }
+
+        let input = StartInput {
+            experience_id: "freven.test".to_string(),
+            mod_id: "freven.test.guest".to_string(),
+            config: ModConfigDocument {
+                format: ModConfigFormat::Toml,
+                text: "motd = \"hello\"".to_string(),
+            },
+        };
+
+        let decoded: TestConfig = input
+            .config_typed()
+            .expect("config_typed should decode TOML");
+        assert_eq!(input.config_text(), "motd = \"hello\"");
+        assert_eq!(decoded.motd, "hello");
     }
 
     #[test]

--- a/crates/freven_guest_sdk/src/lib.rs
+++ b/crates/freven_guest_sdk/src/lib.rs
@@ -7,12 +7,13 @@ use alloc::vec::Vec;
 pub use freven_guest::{
     ActionDeclaration, ActionInput, ActionOutcome, ActionResult, BlockDeclaration,
     CapabilityDeclaration, ChannelBudget, ChannelConfig, ChannelDeclaration, ChannelDirection,
-    ChannelOrdering, ChannelReliability, ComponentCodec, ComponentDeclaration, EffectBatch,
-    GUEST_CONTRACT_VERSION_1, GuestCallbacks, GuestDescription, GuestRegistration, GuestTransport,
-    LifecycleAck, LifecycleHooks, MessageCodec, MessageDeclaration, MessageScope,
-    NativeGuestBuffer, NativeGuestInput, NegotiationRequest, NegotiationResponse,
-    ServerInboundMessage, ServerMessageInput, ServerMessageResult, ServerOutboundMessage,
-    StartInput, TickInput, WorldEffect,
+    ChannelOrdering, ChannelReliability, ClientInboundMessage, ClientMessageInput,
+    ClientMessageResult, ClientOutboundMessage, ClientOutboundMessageScope, ComponentCodec,
+    ComponentDeclaration, EffectBatch, GUEST_CONTRACT_VERSION_1, GuestCallbacks, GuestDescription,
+    GuestRegistration, GuestTransport, LifecycleAck, LifecycleHooks, MessageCodec,
+    MessageDeclaration, MessageHooks, MessageScope, NativeGuestBuffer, NativeGuestInput,
+    NegotiationRequest, NegotiationResponse, ServerInboundMessage, ServerMessageInput,
+    ServerMessageResult, ServerOutboundMessage, StartInput, TickInput, WorldEffect,
 };
 pub use freven_sdk_types::blocks::{BlockDef, RenderLayer};
 use serde::de::DeserializeOwned;
@@ -20,6 +21,7 @@ use serde::de::DeserializeOwned;
 type StartHandler = fn(&StartInput);
 type TickHandler = fn(&TickInput);
 type ActionHandler = fn(ActionContext<'_>) -> ActionResult;
+type ClientMessageHandler = fn(ClientMessageContext<'_>) -> ClientMessageResponse;
 type ServerMessageHandler = fn(ServerMessageContext<'_>) -> ServerMessageResponse;
 
 pub struct GuestModule {
@@ -34,6 +36,7 @@ pub struct GuestModule {
     on_start_server: Option<StartHandler>,
     on_tick_client: Option<TickHandler>,
     on_tick_server: Option<TickHandler>,
+    on_client_messages: Option<ClientMessageHandler>,
     on_server_messages: Option<ServerMessageHandler>,
 }
 
@@ -56,6 +59,7 @@ impl GuestModule {
             on_start_server: None,
             on_tick_client: None,
             on_tick_server: None,
+            on_client_messages: None,
             on_server_messages: None,
         }
     }
@@ -154,6 +158,12 @@ impl GuestModule {
     }
 
     #[must_use]
+    pub fn on_client_messages(mut self, handler: ClientMessageHandler) -> Self {
+        self.on_client_messages = Some(handler);
+        self
+    }
+
+    #[must_use]
     pub fn on_server_messages(mut self, handler: ServerMessageHandler) -> Self {
         self.on_server_messages = Some(handler);
         self
@@ -196,7 +206,10 @@ impl GuestModule {
         GuestCallbacks {
             lifecycle: self.lifecycle_hooks(),
             action: !self.actions.is_empty(),
-            server_messages: self.on_server_messages.is_some(),
+            messages: MessageHooks {
+                client: self.on_client_messages.is_some(),
+                server: self.on_server_messages.is_some(),
+            },
         }
     }
 
@@ -245,6 +258,14 @@ impl GuestModule {
         if let Some(handler) = self.on_tick_server {
             handler(input);
         }
+    }
+
+    #[must_use]
+    pub fn handle_client_messages(&self, input: ClientMessageInput) -> ClientMessageResult {
+        let Some(handler) = self.on_client_messages else {
+            return ClientMessageResponse::default().finish();
+        };
+        handler(ClientMessageContext { input: &input }).finish()
     }
 
     #[must_use]
@@ -397,6 +418,47 @@ impl RejectedActionResponse {
     }
 }
 
+pub struct ClientMessageContext<'a> {
+    input: &'a ClientMessageInput,
+}
+
+impl<'a> ClientMessageContext<'a> {
+    #[must_use]
+    pub fn tick(&self) -> u64 {
+        self.input.tick
+    }
+
+    #[must_use]
+    pub fn dt_millis(&self) -> u32 {
+        self.input.dt_millis
+    }
+
+    #[must_use]
+    pub fn messages(&self) -> &'a [ClientInboundMessage] {
+        &self.input.messages
+    }
+}
+
+#[derive(Default)]
+pub struct ClientMessageResponse {
+    outbound: Vec<ClientOutboundMessage>,
+}
+
+impl ClientMessageResponse {
+    #[must_use]
+    pub fn send(mut self, message: ClientOutboundMessage) -> Self {
+        self.outbound.push(message);
+        self
+    }
+
+    #[must_use]
+    pub fn finish(self) -> ClientMessageResult {
+        ClientMessageResult {
+            outbound: self.outbound,
+        }
+    }
+}
+
 pub struct ServerMessageContext<'a> {
     input: &'a ServerMessageInput,
 }
@@ -497,6 +559,12 @@ pub mod __private {
         postcard::to_allocvec(&result).expect("guest encoding must succeed")
     }
 
+    fn module_client_messages_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
+        let input = decode_required_input::<ClientMessageInput>(input);
+        postcard::to_allocvec(&module.handle_client_messages(input))
+            .expect("guest encoding must succeed")
+    }
+
     fn module_server_messages_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
         let input = decode_required_input::<ServerMessageInput>(input);
         postcard::to_allocvec(&module.handle_server_messages(input))
@@ -556,6 +624,12 @@ pub mod __private {
     pub fn wasm_guest_handle_action(module: &GuestModule, ptr: u32, len: u32) -> u64 {
         with_wasm_input_bytes(ptr, len, |input| {
             encode_to_wasm_guest(&module_handle_action_bytes(module, input))
+        })
+    }
+
+    pub fn wasm_guest_client_messages(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_client_messages_bytes(module, input))
         })
     }
 
@@ -645,6 +719,15 @@ pub mod __private {
         })
     }
 
+    pub fn native_guest_client_messages(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_client_messages_bytes(module, input))
+        })
+    }
+
     pub fn native_guest_server_messages(
         module: &GuestModule,
         input: NativeGuestInput,
@@ -720,7 +803,7 @@ pub mod __private {
         module: &GuestModule,
         lifecycle: LifecycleHooks,
         action: bool,
-        server_messages: bool,
+        messages: MessageHooks,
     ) {
         let callbacks = module.description().callbacks;
         assert_eq!(
@@ -732,8 +815,8 @@ pub mod __private {
             "freven_guest_sdk action export does not match GuestModule::description()",
         );
         assert_eq!(
-            callbacks.server_messages, server_messages,
-            "freven_guest_sdk server message export does not match GuestModule::description()",
+            callbacks.messages, messages,
+            "freven_guest_sdk message export surface does not match GuestModule::description()",
         );
     }
 }
@@ -744,6 +827,7 @@ macro_rules! export_wasm_guest {
         factory: $factory:path
         $(, lifecycle: [$($lifecycle:ident),* $(,)?])?
         $(, actions: $actions:tt)?
+        $(, client_messages: $client_messages:tt)?
         $(, server_messages: $server_messages:tt)?
         $(,)?
     ) => {
@@ -764,7 +848,10 @@ macro_rules! export_wasm_guest {
                 &module,
                 $crate::export_wasm_guest!(@lifecycle_struct $($($lifecycle),*)?),
                 $crate::export_wasm_guest!(@bool $($actions)?),
-                $crate::export_wasm_guest!(@bool $($server_messages)?),
+                $crate::MessageHooks {
+                    client: $crate::export_wasm_guest!(@bool $($client_messages)?),
+                    server: $crate::export_wasm_guest!(@bool $($server_messages)?),
+                },
             );
             $crate::__private::wasm_guest_negotiate(&module, ptr, len)
         }
@@ -774,6 +861,7 @@ macro_rules! export_wasm_guest {
         $crate::export_wasm_guest!(@maybe_export $factory, tick_client, $($($lifecycle),*)?);
         $crate::export_wasm_guest!(@maybe_export $factory, tick_server, $($($lifecycle),*)?);
         $crate::export_wasm_guest!(@maybe_export_action $factory, $($actions)?);
+        $crate::export_wasm_guest!(@maybe_export_client_messages $factory, $($client_messages)?);
         $crate::export_wasm_guest!(@maybe_export_server_messages $factory, $($server_messages)?);
     };
 
@@ -848,6 +936,17 @@ macro_rules! export_wasm_guest {
     (@maybe_export_action $factory:path, false) => {};
     (@maybe_export_action $factory:path) => {};
 
+    (@maybe_export_client_messages $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_client_messages(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::wasm_guest_client_messages(&module, ptr, len)
+        }
+    };
+    (@maybe_export_client_messages $factory:path,) => {};
+    (@maybe_export_client_messages $factory:path, false) => {};
+    (@maybe_export_client_messages $factory:path) => {};
+
     (@maybe_export_server_messages $factory:path, true) => {
         #[unsafe(no_mangle)]
         pub extern "C" fn freven_guest_on_server_messages(ptr: u32, len: u32) -> u64 {
@@ -866,6 +965,7 @@ macro_rules! export_native_guest {
         factory: $factory:path
         $(, lifecycle: [$($lifecycle:ident),* $(,)?])?
         $(, actions: $actions:tt)?
+        $(, client_messages: $client_messages:tt)?
         $(, server_messages: $server_messages:tt)?
         $(,)?
     ) => {
@@ -888,7 +988,10 @@ macro_rules! export_native_guest {
                 &module,
                 $crate::export_native_guest!(@lifecycle_struct $($($lifecycle),*)?),
                 $crate::export_native_guest!(@bool $($actions)?),
-                $crate::export_native_guest!(@bool $($server_messages)?),
+                $crate::MessageHooks {
+                    client: $crate::export_native_guest!(@bool $($client_messages)?),
+                    server: $crate::export_native_guest!(@bool $($server_messages)?),
+                },
             );
             $crate::__private::native_guest_negotiate(&module, input)
         }
@@ -898,6 +1001,7 @@ macro_rules! export_native_guest {
         $crate::export_native_guest!(@maybe_export $factory, tick_client, $($($lifecycle),*)?);
         $crate::export_native_guest!(@maybe_export $factory, tick_server, $($($lifecycle),*)?);
         $crate::export_native_guest!(@maybe_export_action $factory, $($actions)?);
+        $crate::export_native_guest!(@maybe_export_client_messages $factory, $($client_messages)?);
         $crate::export_native_guest!(@maybe_export_server_messages $factory, $($server_messages)?);
     };
 
@@ -982,6 +1086,19 @@ macro_rules! export_native_guest {
     (@maybe_export_action $factory:path, false) => {};
     (@maybe_export_action $factory:path) => {};
 
+    (@maybe_export_client_messages $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_on_client_messages(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::native_guest_client_messages(&module, input)
+        }
+    };
+    (@maybe_export_client_messages $factory:path,) => {};
+    (@maybe_export_client_messages $factory:path, false) => {};
+    (@maybe_export_client_messages $factory:path) => {};
+
     (@maybe_export_server_messages $factory:path, true) => {
         #[unsafe(no_mangle)]
         pub extern "C" fn freven_guest_on_server_messages(
@@ -1002,6 +1119,7 @@ macro_rules! wasm_guest {
         guest_id: $guest_id:expr
         $(, registration: { $($registration:tt)* })?
         $(, lifecycle: { $($lifecycle:ident : $lifecycle_handler:expr),* $(,)? })?
+        $(, client_messages: $client_messages_handler:expr)?
         $(, server_messages: $server_messages_handler:expr)?
         $(, actions: {
             $(
@@ -1021,6 +1139,7 @@ macro_rules! wasm_guest {
                 guest_id: $guest_id
                 $(, registration: { $($registration)* })?
                 $(, lifecycle: { $($lifecycle : $lifecycle_handler),* })?
+                $(, client_messages: $client_messages_handler)?
                 $(, server_messages: $server_messages_handler)?
                 $(, actions: {
                     $(
@@ -1037,6 +1156,7 @@ macro_rules! wasm_guest {
             @export
             factory: __freven_guest_sdk_module
             $(, lifecycle: [$($lifecycle),*])?
+            $(, client_messages: [$client_messages_handler])?
             $(, server_messages: [$server_messages_handler])?
             $(, actions: [$($action_key),*])?
         );
@@ -1047,6 +1167,7 @@ macro_rules! wasm_guest {
         guest_id: $guest_id:expr
         $(, registration: { $($registration:tt)* })?
         $(, lifecycle: { $($lifecycle:ident : $lifecycle_handler:expr),* $(,)? })?
+        $(, client_messages: $client_messages_handler:expr)?
         $(, server_messages: $server_messages_handler:expr)?
         $(, actions: {
             $(
@@ -1074,6 +1195,9 @@ macro_rules! wasm_guest {
             )*
         )?
         $(
+            let module = module.on_client_messages($client_messages_handler);
+        )?
+        $(
             let module = module.on_server_messages($server_messages_handler);
         )?
         $(
@@ -1095,10 +1219,25 @@ macro_rules! wasm_guest {
             $(, lifecycle: [$($lifecycle),*])?
         );
     };
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, client_messages: [$handler:expr]) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+            , client_messages: true
+        );
+    };
     (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, server_messages: [$handler:expr]) => {
         $crate::export_wasm_guest!(
             factory: $factory
             $(, lifecycle: [$($lifecycle),*])?
+            , server_messages: true
+        );
+    };
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, client_messages: [$client_handler:expr], server_messages: [$server_handler:expr]) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+            , client_messages: true
             , server_messages: true
         );
     };
@@ -1115,6 +1254,21 @@ macro_rules! wasm_guest {
             , actions: true
         );
     };
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, client_messages: [$handler:expr], actions: []) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+            , client_messages: true
+        );
+    };
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, client_messages: [$handler:expr], actions: [$first:expr $(, $rest:expr)*]) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+            , actions: true
+            , client_messages: true
+        );
+    };
     (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, server_messages: [$handler:expr], actions: []) => {
         $crate::export_wasm_guest!(
             factory: $factory
@@ -1127,6 +1281,23 @@ macro_rules! wasm_guest {
             factory: $factory
             $(, lifecycle: [$($lifecycle),*])?
             , actions: true
+            , server_messages: true
+        );
+    };
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, client_messages: [$client_handler:expr], server_messages: [$server_handler:expr], actions: []) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+            , client_messages: true
+            , server_messages: true
+        );
+    };
+    (@export factory: $factory:path $(, lifecycle: [$($lifecycle:ident),*])?, client_messages: [$client_handler:expr], server_messages: [$server_handler:expr], actions: [$first:expr $(, $rest:expr)*]) => {
+        $crate::export_wasm_guest!(
+            factory: $factory
+            $(, lifecycle: [$($lifecycle),*])?
+            , actions: true
+            , client_messages: true
             , server_messages: true
         );
     };
@@ -1218,7 +1389,7 @@ mod tests {
         assert!(description.callbacks.lifecycle.start_server);
         assert!(description.callbacks.lifecycle.tick_server);
         assert!(description.callbacks.action);
-        assert!(description.callbacks.server_messages);
+        assert!(description.callbacks.messages.server);
     }
 
     #[test]
@@ -1333,14 +1504,25 @@ mod tests {
                 ..Default::default()
             },
             true,
-            true,
+            MessageHooks {
+                client: false,
+                server: true,
+            },
         );
     }
 
     #[test]
     #[should_panic(expected = "freven_guest_sdk export lifecycle does not match")]
     fn export_surface_assertion_rejects_lifecycle_mismatch() {
-        __private::assert_export_surface(&module(), LifecycleHooks::default(), true, true);
+        __private::assert_export_surface(
+            &module(),
+            LifecycleHooks::default(),
+            true,
+            MessageHooks {
+                client: false,
+                server: true,
+            },
+        );
     }
 
     #[test]
@@ -1354,12 +1536,15 @@ mod tests {
                 ..Default::default()
             },
             false,
-            true,
+            MessageHooks {
+                client: false,
+                server: true,
+            },
         );
     }
 
     #[test]
-    #[should_panic(expected = "freven_guest_sdk server message export does not match")]
+    #[should_panic(expected = "freven_guest_sdk message export surface does not match")]
     fn export_surface_assertion_rejects_server_message_mismatch() {
         __private::assert_export_surface(
             &module(),
@@ -1369,7 +1554,10 @@ mod tests {
                 ..Default::default()
             },
             true,
-            false,
+            MessageHooks {
+                client: false,
+                server: false,
+            },
         );
     }
 
@@ -1426,7 +1614,7 @@ mod tests {
             }
         );
         assert!(description.callbacks.action);
-        assert!(description.callbacks.server_messages);
+        assert!(description.callbacks.messages.server);
     }
 
     #[test]

--- a/docs/EXTERNAL_MOD_IPC_v1.md
+++ b/docs/EXTERNAL_MOD_IPC_v1.md
@@ -55,6 +55,9 @@ process boundary.
 
 ## Behavioral rules
 
+`StartInput` carries `experience_id`, `mod_id`, and the resolved per-mod config
+document (`ModConfigDocument`, currently TOML text).
+
 - Host enforces per-call timeout for handshake, negotiation, steady-state
   lifecycle calls, and action IPC.
 - Negotiation must select `GUEST_CONTRACT_VERSION_1` and return a

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -58,7 +58,12 @@ Host and guest negotiate before any guest callback.
 - `tick_client`
 - `tick_server`
 
-`on_start_common` is intentionally not part of the guest contract yet.
+`MessageHooks` currently exposes:
+
+- `client`
+- `server`
+
+`on_start_common` is not part of the guest contract.
 
 Registration/callback invariants:
 
@@ -76,15 +81,13 @@ Registration/callback invariants:
 - `ActionResult.effects` currently supports world effects through `WorldEffect`
 - `ActionInput.player_position_m` is the first canonical player-read slice
 
-## Server message path
+## Message path
 
-- Host sends `ServerMessageInput`
-- Guest returns `ServerMessageResult`
-- This is a dedicated callback family, separate from actions and lifecycle
-- `ServerMessageResult.outbound` carries `ServerOutboundMessage` sends
-- host routing is channel/message-contract checked:
-  inbound messages are delivered only for declared server-readable channels and declared message ids
-- outbound sends must use declared message ids and declared server-writable channels
+- Host sends `ClientMessageInput` / `ServerMessageInput`
+- Guest returns `ClientMessageResult` / `ServerMessageResult`
+- Messaging is a dedicated callback family, separate from lifecycle and actions
+- outbound sends must use declared message ids and declared side-appropriate writable channels
+- inbound delivery is routed only for declared side-appropriate readable channels and declared message ids
 - unsupported/unknown message scope mapping is a guest fault, not a silent fallback
 
 ## Lifecycle path
@@ -110,5 +113,5 @@ If a guest violates the contract or faults during a runtime session:
 For action callbacks, "faults" include host-side failure to apply the guest's
 declared world effects after the `ActionResult` is decoded and validated.
 
-For server-message callbacks, faults include invalid inbound scope mapping and
+For message callbacks, faults include invalid inbound scope mapping and
 outbound sends that violate the negotiated channel/message contract.

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -47,6 +47,9 @@ Host and guest negotiate before any guest callback.
 - `blocks`
 - `components`
 - `messages`
+- `worldgen`
+- `character_controllers`
+- `client_control_providers`
 - `channels`
 - `actions`
 - `capabilities`
@@ -70,8 +73,20 @@ Registration/callback invariants:
 - `registration.actions` and `callbacks.action` are one family:
   declaring actions requires `callbacks.action = true`
 - `callbacks.action = true` requires at least one declared action
+- provider families (`worldgen`, `character_controllers`,
+  `client_control_providers`) are part of the canonical public declaration
+  model even when a given execution/policy class does not host them yet
 - capability keys must be non-empty
 - declared capability keys must exist in the resolved host capability table
+
+Current hosting policy:
+
+- compile-time/builtin registration hosts all currently implemented declaration
+  families
+- runtime-loaded guest transports may declare provider families canonically, but
+  host policy currently rejects them explicitly because guest factory/runtime
+  hosting for those families does not exist yet
+- this is an execution/policy gate, not a separate public declaration model
 
 ## Action path
 
@@ -96,6 +111,16 @@ Lifecycle calls are currently ack-only.
 
 - Host sends `StartInput` or `TickInput`
 - Guest returns `LifecycleAck`
+
+`StartInput` carries:
+
+- `experience_id`
+- `mod_id`
+- `config`
+
+`config` is the resolved per-mod config document from `experience.config."<mod_id>"`.
+Contract v1 currently serializes that document as TOML text with an explicit
+`ModConfigFormat`.
 
 There is intentionally no lifecycle effect/output channel in contract v1.
 Lifecycle outputs are deferred until the runtime supports a real, honest

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -20,8 +20,10 @@ A native mod dynamic library must export these symbols:
 - `freven_guest_negotiate(input: NativeGuestInput) -> NativeGuestBuffer`
 - `freven_guest_handle_action(input: NativeGuestInput) -> NativeGuestBuffer` when
   `callbacks.action = true`
+- `freven_guest_on_client_messages(input: NativeGuestInput) -> NativeGuestBuffer`
+  when `callbacks.messages.client = true`
 - `freven_guest_on_server_messages(input: NativeGuestInput) -> NativeGuestBuffer`
-  when `callbacks.server_messages = true`
+  when `callbacks.messages.server = true`
 - `freven_guest_on_start_client(input: NativeGuestInput) -> NativeGuestBuffer`
   when `callbacks.lifecycle.start_client = true`
 - `freven_guest_on_start_server(input: NativeGuestInput) -> NativeGuestBuffer`
@@ -72,6 +74,7 @@ Returned bytes are postcard-encoded `freven_guest` contract types:
 
 - `freven_guest_negotiate` takes `NegotiationRequest` and returns `NegotiationResponse`
 - `freven_guest_handle_action` takes `ActionInput` and returns `ActionResult`
+- `freven_guest_on_client_messages` takes `ClientMessageInput` and returns `ClientMessageResult`
 - `freven_guest_on_server_messages` takes `ServerMessageInput` and returns `ServerMessageResult`
 - lifecycle exports take `StartInput` or `TickInput` and return `LifecycleAck`
 
@@ -93,11 +96,11 @@ Runtime validates and enforces:
 - max byte caps for negotiation/result/input payload before copying
 - declared callback surface exactly matches the exported symbol surface
 - dual-side lifecycle declarations are allowed; the runtime hosts the active side as a subset for the current session
-- server-message routing uses the negotiated registration contract:
-  inbound delivery only for declared server-readable channels, outbound sends only for declared server-writable channels and declared message ids
+- message routing uses the negotiated registration contract:
+  inbound delivery only for declared side-appropriate readable channels, outbound sends only for declared side-appropriate writable channels and declared message ids
 
 On decode/validation/contract errors, attach fails.
-On lifecycle, action-call, or server-message contract faults, runtime disables that guest mod for the
+On lifecycle, action-call, or message contract faults, runtime disables that guest mod for the
 current runtime session and later lifecycle/action calls reject. That includes
 host-side failure to apply guest-declared world effects after a valid
 `ActionResult` returns.

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -78,6 +78,9 @@ Returned bytes are postcard-encoded `freven_guest` contract types:
 - `freven_guest_on_server_messages` takes `ServerMessageInput` and returns `ServerMessageResult`
 - lifecycle exports take `StartInput` or `TickInput` and return `LifecycleAck`
 
+`StartInput` carries `experience_id`, `mod_id`, and the resolved per-mod config
+document (`ModConfigDocument`, currently TOML text).
+
 `ActionInput` carries `binding_id`, `player_id`, `level_id`, `stream_epoch`,
 `action_seq`, `at_input_seq`, and opaque payload bytes. Those fields inside the
 postcard payload are the single source of truth for action context.
@@ -98,6 +101,10 @@ Runtime validates and enforces:
 - dual-side lifecycle declarations are allowed; the runtime hosts the active side as a subset for the current session
 - message routing uses the negotiated registration contract:
   inbound delivery only for declared side-appropriate readable channels, outbound sends only for declared side-appropriate writable channels and declared message ids
+- provider-family declarations (`worldgen`, `character_controllers`,
+  `client_control_providers`) are part of the canonical guest model, but native
+  guest execution still rejects them explicitly because guest-side provider
+  hosting is not implemented yet
 
 On decode/validation/contract errors, attach fails.
 On lifecycle, action-call, or message contract faults, runtime disables that guest mod for the

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -64,6 +64,8 @@ Host behavior:
 - validates `selected_contract_version`
 - validates `GuestDescription.callbacks` against exported Wasm symbols
 - registers `GuestDescription.registration` into the canonical host runtime
+- rejects canonically declared provider families when host execution/policy does
+  not support guest-side provider hosting yet
 - maps runtime action kind to `registration.actions[].binding_id` for callback dispatch
 
 ### Lifecycle inputs and outputs
@@ -71,6 +73,17 @@ Host behavior:
 - `freven_guest_on_start_*` input: `StartInput`
 - `freven_guest_on_tick_*` input: `TickInput`
 - lifecycle output: `LifecycleAck`
+
+`StartInput` includes:
+
+- `experience_id: String`
+- `mod_id: String`
+- `config: ModConfigDocument`
+
+`ModConfigDocument` is currently:
+
+- `format: ModConfigFormat` (`toml`)
+- `text: String`
 
 Lifecycle is intentionally ack-only in guest contract v1. Returning any richer
 lifecycle effect payload is not part of the contract.

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -12,7 +12,7 @@ recommended getting-started path.
 
 ## Scope
 
-- Supports negotiation, declaration registration, lifecycle callbacks, server-message callbacks, and action handling over Wasm
+- Supports negotiation, declaration registration, lifecycle callbacks, side-specific message callbacks, and action handling over Wasm
   ptr/len calls.
 - Host runs modules with no WASI and no host imports by default.
 - `[capabilities]` in `mod.toml` is enforced by runtime with a strict allowlist.
@@ -25,7 +25,8 @@ A module must export these symbols:
 - `freven_guest_dealloc(ptr: u32, size: u32)`
 - `freven_guest_negotiate(ptr: u32, len: u32) -> u64`
 - `freven_guest_handle_action(ptr: u32, len: u32) -> u64` if `callbacks.action = true`
-- `freven_guest_on_server_messages(ptr: u32, len: u32) -> u64` if `callbacks.server_messages = true`
+- `freven_guest_on_client_messages(ptr: u32, len: u32) -> u64` if `callbacks.messages.client = true`
+- `freven_guest_on_server_messages(ptr: u32, len: u32) -> u64` if `callbacks.messages.server = true`
 - linear memory export named `memory`
 
 The negotiated `GuestDescription` must also be internally coherent:
@@ -87,12 +88,12 @@ lifecycle effect payload is not part of the contract.
 - `player_position_m: Option<[f32; 3]>`
 - `payload: &[u8]` (opaque client/server action payload)
 
-### Server message callback
+### Message callbacks
 
-- `freven_guest_on_server_messages` input: `ServerMessageInput`
-- output: `ServerMessageResult`
-- the host routes inbound server-side mod messages only for the guest's declared server-readable channels
-- guest outbound sends must use declared message ids and declared server-writable channels
+- `freven_guest_on_client_messages` input: `ClientMessageInput`, output: `ClientMessageResult`
+- `freven_guest_on_server_messages` input: `ServerMessageInput`, output: `ServerMessageResult`
+- the host routes inbound mod messages only for the guest's declared side-appropriate readable channels
+- guest outbound sends must use declared message ids and declared side-appropriate writable channels
 - unsupported message-scope mapping is rejected explicitly; the runtime does not silently coerce scope
 
 ### Action result (`freven_guest_handle_action` return bytes)

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -75,6 +75,7 @@ What the SDK hides:
 What stays explicit:
 
 - guest id
+- declared registration families
 - declared lifecycle hooks
 - declared action bindings
 - exported Wasm capability surface generated from that same declaration
@@ -84,6 +85,12 @@ What stays explicit:
 hooks and action bindings you write are the same data used to build the
 canonical `GuestDescription` and to emit the Wasm export table, so the two
 surfaces cannot drift in normal authoring.
+
+The canonical registration model now includes blocks, components, messages,
+channels, actions, capabilities, worldgen keys, character-controller keys, and
+client-control-provider keys. Wasm guests may declare the provider families,
+but the runtime still policy-gates them explicitly because guest-side provider
+hosting is not implemented yet.
 
 `GuestModule` plus `export_wasm_guest!(...)` still exist as a lower-level escape
 hatch for raw ABI fixtures, runtime validation, or unusual tests, but they are
@@ -115,6 +122,19 @@ Two SDK hardening rules matter here:
   In practice this means a contract / transport / host-delivery violation on
   the action callback path faults the guest call instead of fabricating a
   placeholder input.
+
+## Start-time config semantics
+
+`StartInput` now carries:
+
+- `experience_id`
+- `mod_id`
+- `config`
+
+The config document is the resolved per-mod `experience.config."<mod_id>"`
+table serialized as TOML text. `freven_guest_sdk::StartInputExt` exposes
+`config_text()` and `config_typed::<T>()` helpers so guest authors can read the
+same per-mod config semantics compile-time mods already had.
 
 ## Transport guidance
 

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -22,13 +22,15 @@ The canonical guest lifecycle today is:
 - `on_start_server`
 - `on_tick_client`
 - `on_tick_server`
+- `on_client_messages`
+- `on_server_messages`
 - action handling through one action entrypoint plus declared bindings
 
 Current contract limits:
 
 - lifecycle hooks are ack-only in guest contract v1
 - lifecycle callbacks do not return effect batches yet
-- `on_start_common` is not part of the runtime-loaded guest contract yet
+- `on_start_common` is not part of the runtime-loaded guest contract
 
 Those boundaries are intentional. The SDK does not pretend lifecycle output or
 cross-transport parity exists when it does not.


### PR DESCRIPTION
## Summary
This PR completes the next two phases of the public guest contract cleanup in `freven-sdk`.

Phase 2a unifies guest lifecycle and messaging around explicit client/server hooks instead of the old server-only callback surface.

Phase 2b broadens the canonical declaration model so `freven_guest` becomes the breadth-complete public contract, with `freven_api` re-exporting that model and `freven_guest_sdk` exposing matching builders and config helpers.

## What changed
- replaced the old server-only message callback surface with explicit client and server message hooks
- updated the public guest lifecycle and messaging contracts
- expanded the canonical declaration model with provider-family declarations
- added start-time mod config transport to the public guest model
- re-exported the canonical guest model through `freven_api`
- extended `freven_guest_sdk` builders and config helpers
- refreshed ABI, IPC, authoring, and contract documentation
- updated lockfiles and package metadata where needed

## Why
This makes the SDK surface clearer and more future-proof:
- one canonical public declaration model
- one explicit lifecycle/message model across runtimes
- cleaner separation between public contract breadth and current runtime policy limits
- better documentation for mod authors and runtime implementers

## Notes
Some declarations are now part of the canonical public model even where runtime support is still policy-gated on the engine side. This PR intentionally documents and exposes the full contract surface from the SDK perspective.