### PR TITLE
Canonize guest runtime services in the public SDK

### DIFF
--- a/crates/freven_api/src/lib.rs
+++ b/crates/freven_api/src/lib.rs
@@ -20,6 +20,8 @@ pub use freven_guest::{
     GuestCallbacks as ModCallbackModel, GuestRegistration as ModDeclarationModel,
     LifecycleHooks as LifecycleCallbackModel, MessageHooks as MessageCallbackModel,
     ModConfigDocument as GuestModConfigDocument, ModConfigFormat as GuestModConfigFormat,
+    RuntimeCommandOutput, RuntimeEntityTarget, RuntimeLevelRef, RuntimeOutput, RuntimeReadRequest,
+    RuntimeServiceRequest, RuntimeServiceResponse, RuntimeSideRequest, WorldCommand,
     WorldGenDeclaration,
 };
 pub use freven_sdk_types::blocks::{BlockDef, BlockRuntimeId, RenderLayer};
@@ -92,6 +94,7 @@ pub struct ActionContext<'a> {
     pub world_read: Option<&'a dyn ActionWorldRead>,
     pub world_edit: Option<&'a mut dyn ActionWorldEdit>,
     pub character_physics: Option<&'a dyn CharacterPhysicsQuery>,
+    pub services: Option<&'a mut dyn Services>,
     pub player_id: u64,
     pub at_input_seq: u32,
 }
@@ -102,6 +105,7 @@ impl<'a> ActionContext<'a> {
         world_read: Option<&'a dyn ActionWorldRead>,
         world_edit: Option<&'a mut dyn ActionWorldEdit>,
         character_physics: Option<&'a dyn CharacterPhysicsQuery>,
+        services: Option<&'a mut dyn Services>,
         player_id: u64,
         at_input_seq: u32,
     ) -> Self {
@@ -109,6 +113,7 @@ impl<'a> ActionContext<'a> {
             world_read,
             world_edit,
             character_physics,
+            services,
             player_id,
             at_input_seq,
         }
@@ -524,7 +529,34 @@ pub type ClientMessagesHook = for<'a> fn(&mut ClientMessagesApi<'a>);
 pub type ServerMessagesHook = for<'a> fn(&mut ServerMessagesApi<'a>);
 
 /// Runtime-provided services exposed to SDK hooks.
-pub trait Services {}
+pub trait Services {
+    fn guest_runtime_service(
+        &mut self,
+        _request: &RuntimeServiceRequest,
+    ) -> RuntimeServiceResponse {
+        RuntimeServiceResponse::Unsupported
+    }
+
+    fn apply_guest_runtime_commands(
+        &mut self,
+        commands: &RuntimeCommandOutput,
+    ) -> Result<(), RuntimeOutputApplyError> {
+        if commands.is_empty() {
+            Ok(())
+        } else {
+            Err(RuntimeOutputApplyError::UnsupportedFamily { family: "commands" })
+        }
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RuntimeOutputApplyError {
+    #[error("runtime output family '{family}' is not supported in this host context")]
+    UnsupportedFamily { family: &'static str },
+    #[error("runtime output application failed: {message}")]
+    Rejected { message: String },
+}
 
 /// Empty services implementation used by runtimes that do not expose services yet.
 #[derive(Debug, Default)]
@@ -950,6 +982,7 @@ impl<'a> ClientApi<'a> {
 pub struct ClientMessagesApi<'a> {
     pub tick: u64,
     pub dt: Duration,
+    pub services: &'a mut dyn Services,
     pub inbound: &'a [ClientInboundMessage],
     pub sender: &'a mut dyn ClientMessageSender,
 }
@@ -959,12 +992,14 @@ impl<'a> ClientMessagesApi<'a> {
     pub fn new(
         tick: u64,
         dt: Duration,
+        services: &'a mut dyn Services,
         inbound: &'a [ClientInboundMessage],
         sender: &'a mut dyn ClientMessageSender,
     ) -> Self {
         Self {
             tick,
             dt,
+            services,
             inbound,
             sender,
         }
@@ -975,6 +1010,7 @@ impl<'a> ClientMessagesApi<'a> {
 pub struct ServerMessagesApi<'a> {
     pub tick: u64,
     pub dt: Duration,
+    pub services: &'a mut dyn Services,
     pub inbound: &'a [ServerInboundMessage],
     pub sender: &'a mut dyn ServerMessageSender,
 }
@@ -984,12 +1020,14 @@ impl<'a> ServerMessagesApi<'a> {
     pub fn new(
         tick: u64,
         dt: Duration,
+        services: &'a mut dyn Services,
         inbound: &'a [ServerInboundMessage],
         sender: &'a mut dyn ServerMessageSender,
     ) -> Self {
         Self {
             tick,
             dt,
+            services,
             inbound,
             sender,
         }

--- a/crates/freven_guest/src/lib.rs
+++ b/crates/freven_guest/src/lib.rs
@@ -7,6 +7,7 @@
 extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
+use core::ffi::c_void;
 use freven_sdk_types::blocks::BlockDef;
 use serde::{Deserialize, Serialize};
 
@@ -50,6 +51,31 @@ impl NativeGuestBuffer {
         Self {
             ptr: core::ptr::null_mut(),
             len: 0,
+        }
+    }
+}
+
+pub type NativeRuntimeServiceCall = unsafe extern "C" fn(
+    ctx: *mut c_void,
+    req_ptr: *const u8,
+    req_len: usize,
+    resp_ptr: *mut u8,
+    resp_cap: usize,
+) -> usize;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct NativeRuntimeBridge {
+    pub ctx: *mut c_void,
+    pub call: Option<NativeRuntimeServiceCall>,
+}
+
+impl NativeRuntimeBridge {
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            ctx: core::ptr::null_mut(),
+            call: None,
         }
     }
 }
@@ -262,24 +288,27 @@ pub struct ServerMessageInput {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct LifecycleAck {}
+#[serde(default)]
+pub struct LifecycleResult {
+    pub output: RuntimeOutput,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActionResult {
     pub outcome: ActionOutcome,
-    pub effects: EffectBatch,
+    pub output: RuntimeOutput,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct ClientMessageResult {
-    pub outbound: Vec<ClientOutboundMessage>,
+    pub output: RuntimeOutput,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct ServerMessageResult {
-    pub outbound: Vec<ServerOutboundMessage>,
+    pub output: RuntimeOutput,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -291,11 +320,39 @@ pub enum ActionOutcome {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
-pub struct EffectBatch {
-    pub world: Vec<WorldEffect>,
+pub struct RuntimeOutput {
+    pub messages: RuntimeMessageOutput,
+    pub commands: RuntimeCommandOutput,
 }
 
-impl EffectBatch {
+impl RuntimeOutput {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.messages.is_empty() && self.commands.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct RuntimeMessageOutput {
+    pub client: Vec<ClientOutboundMessage>,
+    pub server: Vec<ServerOutboundMessage>,
+}
+
+impl RuntimeMessageOutput {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.client.is_empty() && self.server.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct RuntimeCommandOutput {
+    pub world: Vec<WorldCommand>,
+}
+
+impl RuntimeCommandOutput {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.world.is_empty()
@@ -303,8 +360,12 @@ impl EffectBatch {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum WorldEffect {
-    SetBlock { pos: (i32, i32, i32), block_id: u8 },
+pub enum WorldCommand {
+    SetBlock {
+        pos: (i32, i32, i32),
+        block_id: u8,
+        expected_old: Option<u8>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -357,4 +418,62 @@ pub enum MessageScope {
 pub enum ClientOutboundMessageScope {
     Global,
     ActiveLevel,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeLevelRef {
+    pub level_id: u32,
+    pub stream_epoch: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RuntimeEntityTarget {
+    Player { player_id: u64 },
+    Entity { entity_id: u32 },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RuntimeReadRequest {
+    WorldBlock {
+        pos: (i32, i32, i32),
+    },
+    PlayerPosition {
+        player_id: u64,
+    },
+    PlayerDisplayName {
+        player_id: u64,
+    },
+    PlayerEntityId {
+        player_id: u64,
+    },
+    EntityComponentBytes {
+        entity: RuntimeEntityTarget,
+        component_key: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RuntimeSideRequest {
+    ClientActiveLevel,
+    ClientNextInputSeq,
+    ServerPlayerConnected { player_id: u64 },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RuntimeServiceRequest {
+    Read(RuntimeReadRequest),
+    Side(RuntimeSideRequest),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum RuntimeServiceResponse {
+    WorldBlock(Option<u8>),
+    PlayerPosition(Option<[f32; 3]>),
+    PlayerDisplayName(Option<String>),
+    PlayerEntityId(Option<u32>),
+    EntityComponentBytes(Option<Vec<u8>>),
+    ClientActiveLevel(Option<RuntimeLevelRef>),
+    ClientNextInputSeq(Option<u32>),
+    ServerPlayerConnected(Option<bool>),
+    Unsupported,
 }

--- a/crates/freven_guest_sdk/README.md
+++ b/crates/freven_guest_sdk/README.md
@@ -54,18 +54,20 @@ intentionally need to wire the raw surface yourself.
 
 ## Current boundaries
 
-- Lifecycle hooks are still ack-only.
+- Lifecycle hooks return `LifecycleResult`.
 - `registration.actions` and `callbacks.action` stay coupled:
   actions imply the callback family, and the callback family is not valid without declared actions.
-- Rejected actions are effect-free by API shape in the SDK:
-  `ActionResponse::rejected()` can be finished, but it does not expose world-effect
-  builder methods.
+- Rejected actions are command-free by API shape in the SDK:
+  `ActionResponse::rejected()` can be finished, but it does not expose
+  authoritative-command builder methods.
 - Action callbacks require a real decoded `ActionInput`:
   empty or malformed action payload bytes are not silently synthesized by the
   SDK. On the runtime path, that becomes a contract / transport / host-delivery
   fault for the guest call rather than a fabricated placeholder input.
 - Runtime messaging is a dedicated callback family on both sides
   (`on_client_messages`, `on_server_messages`) rather than being stuffed into lifecycle or actions.
+- Runtime-loaded guests use explicit runtime services for reads and side-specific
+  facilities rather than callback-specific hacks.
 - Runtime delivery is contract-checked symmetrically:
   undeclared inbound channels/message ids fault the guest the same way undeclared outbound use does.
 - Declarations now cover blocks, components, messages, worldgen,

--- a/crates/freven_guest_sdk/src/lib.rs
+++ b/crates/freven_guest_sdk/src/lib.rs
@@ -2,7 +2,8 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
+use core::cell::RefCell;
 
 pub use freven_guest::{
     ActionDeclaration, ActionInput, ActionOutcome, ActionResult, BlockDeclaration,
@@ -10,21 +11,29 @@ pub use freven_guest::{
     ChannelOrdering, ChannelReliability, CharacterControllerDeclaration,
     ClientControlProviderDeclaration, ClientInboundMessage, ClientMessageInput,
     ClientMessageResult, ClientOutboundMessage, ClientOutboundMessageScope, ComponentCodec,
-    ComponentDeclaration, EffectBatch, GUEST_CONTRACT_VERSION_1, GuestCallbacks, GuestDescription,
-    GuestRegistration, GuestTransport, LifecycleAck, LifecycleHooks, MessageCodec,
+    ComponentDeclaration, GUEST_CONTRACT_VERSION_1, GuestCallbacks, GuestDescription,
+    GuestRegistration, GuestTransport, LifecycleHooks, LifecycleResult, MessageCodec,
     MessageDeclaration, MessageHooks, MessageScope, ModConfigDocument, ModConfigFormat,
-    NativeGuestBuffer, NativeGuestInput, NegotiationRequest, NegotiationResponse,
-    ServerInboundMessage, ServerMessageInput, ServerMessageResult, ServerOutboundMessage,
-    StartInput, TickInput, WorldEffect, WorldGenDeclaration,
+    NativeGuestBuffer, NativeGuestInput, NativeRuntimeBridge, NegotiationRequest,
+    NegotiationResponse, RuntimeCommandOutput, RuntimeEntityTarget, RuntimeLevelRef,
+    RuntimeMessageOutput, RuntimeOutput, RuntimeReadRequest, RuntimeServiceRequest,
+    RuntimeServiceResponse, RuntimeSideRequest, ServerInboundMessage, ServerMessageInput,
+    ServerMessageResult, ServerOutboundMessage, StartInput, TickInput, WorldCommand,
+    WorldGenDeclaration,
 };
 pub use freven_sdk_types::blocks::{BlockDef, RenderLayer};
 use serde::de::DeserializeOwned;
 
-type StartHandler = fn(&StartInput);
-type TickHandler = fn(&TickInput);
+type StartHandler = fn(StartContext<'_>) -> LifecycleResult;
+type TickHandler = fn(TickContext<'_>) -> LifecycleResult;
 type ActionHandler = fn(ActionContext<'_>) -> ActionResult;
 type ClientMessageHandler = fn(ClientMessageContext<'_>) -> ClientMessageResponse;
 type ServerMessageHandler = fn(ServerMessageContext<'_>) -> ServerMessageResponse;
+
+thread_local! {
+    static NATIVE_RUNTIME_BRIDGE: RefCell<NativeRuntimeBridge> =
+        const { RefCell::new(NativeRuntimeBridge::empty()) };
+}
 
 pub struct GuestModule {
     guest_id: &'static str,
@@ -292,28 +301,32 @@ impl GuestModule {
         }
     }
 
-    pub fn handle_start_client(&self, input: &StartInput) {
-        if let Some(handler) = self.on_start_client {
-            handler(input);
-        }
+    pub fn handle_start_client(&self, input: &StartInput) -> LifecycleResult {
+        let Some(handler) = self.on_start_client else {
+            return LifecycleResponse::default().finish();
+        };
+        handler(StartContext { input })
     }
 
-    pub fn handle_start_server(&self, input: &StartInput) {
-        if let Some(handler) = self.on_start_server {
-            handler(input);
-        }
+    pub fn handle_start_server(&self, input: &StartInput) -> LifecycleResult {
+        let Some(handler) = self.on_start_server else {
+            return LifecycleResponse::default().finish();
+        };
+        handler(StartContext { input })
     }
 
-    pub fn handle_tick_client(&self, input: &TickInput) {
-        if let Some(handler) = self.on_tick_client {
-            handler(input);
-        }
+    pub fn handle_tick_client(&self, input: &TickInput) -> LifecycleResult {
+        let Some(handler) = self.on_tick_client else {
+            return LifecycleResponse::default().finish();
+        };
+        handler(TickContext { input })
     }
 
-    pub fn handle_tick_server(&self, input: &TickInput) {
-        if let Some(handler) = self.on_tick_server {
-            handler(input);
-        }
+    pub fn handle_tick_server(&self, input: &TickInput) -> LifecycleResult {
+        let Some(handler) = self.on_tick_server else {
+            return LifecycleResponse::default().finish();
+        };
+        handler(TickContext { input })
     }
 
     #[must_use]
@@ -419,6 +432,63 @@ impl<'a> ActionContext<'a> {
     {
         postcard::from_bytes(self.input.payload)
     }
+
+    #[must_use]
+    pub fn services(&self) -> RuntimeServices {
+        RuntimeServices
+    }
+}
+
+pub struct StartContext<'a> {
+    input: &'a StartInput,
+}
+
+impl<'a> StartContext<'a> {
+    #[must_use]
+    pub fn input(&self) -> &'a StartInput {
+        self.input
+    }
+
+    #[must_use]
+    pub fn experience_id(&self) -> &'a str {
+        &self.input.experience_id
+    }
+
+    #[must_use]
+    pub fn mod_id(&self) -> &'a str {
+        &self.input.mod_id
+    }
+
+    #[must_use]
+    pub fn services(&self) -> RuntimeServices {
+        RuntimeServices
+    }
+}
+
+pub struct TickContext<'a> {
+    input: &'a TickInput,
+}
+
+impl<'a> TickContext<'a> {
+    #[must_use]
+    pub fn input(&self) -> &'a TickInput {
+        self.input
+    }
+
+    #[must_use]
+    pub fn tick(&self) -> u64 {
+        self.input.tick
+    }
+
+    #[must_use]
+    pub fn dt_millis(&self) -> u32 {
+        self.input.dt_millis
+    }
+
+    #[must_use]
+    pub fn services(&self) -> RuntimeServices {
+        RuntimeServices
+    }
 }
 
 pub trait StartInputExt {
@@ -443,55 +513,188 @@ impl StartInputExt for StartInput {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RuntimeServices;
+
+impl RuntimeServices {
+    #[must_use]
+    pub fn block_world(self, pos: (i32, i32, i32)) -> Option<u8> {
+        match runtime_service_call(RuntimeServiceRequest::Read(
+            RuntimeReadRequest::WorldBlock { pos },
+        )) {
+            RuntimeServiceResponse::WorldBlock(value) => value,
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn player_position(self, player_id: u64) -> Option<[f32; 3]> {
+        match runtime_service_call(RuntimeServiceRequest::Read(
+            RuntimeReadRequest::PlayerPosition { player_id },
+        )) {
+            RuntimeServiceResponse::PlayerPosition(value) => value,
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn player_display_name(self, player_id: u64) -> Option<String> {
+        match runtime_service_call(RuntimeServiceRequest::Read(
+            RuntimeReadRequest::PlayerDisplayName { player_id },
+        )) {
+            RuntimeServiceResponse::PlayerDisplayName(value) => value,
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn player_entity_id(self, player_id: u64) -> Option<u32> {
+        match runtime_service_call(RuntimeServiceRequest::Read(
+            RuntimeReadRequest::PlayerEntityId { player_id },
+        )) {
+            RuntimeServiceResponse::PlayerEntityId(value) => value,
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn entity_component_bytes(
+        self,
+        entity: RuntimeEntityTarget,
+        component_key: &str,
+    ) -> Option<Vec<u8>> {
+        match runtime_service_call(RuntimeServiceRequest::Read(
+            RuntimeReadRequest::EntityComponentBytes {
+                entity,
+                component_key: component_key.to_string(),
+            },
+        )) {
+            RuntimeServiceResponse::EntityComponentBytes(value) => value,
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn client_active_level(self) -> Option<RuntimeLevelRef> {
+        match runtime_service_call(RuntimeServiceRequest::Side(
+            RuntimeSideRequest::ClientActiveLevel,
+        )) {
+            RuntimeServiceResponse::ClientActiveLevel(value) => value,
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn client_next_input_seq(self) -> Option<u32> {
+        match runtime_service_call(RuntimeServiceRequest::Side(
+            RuntimeSideRequest::ClientNextInputSeq,
+        )) {
+            RuntimeServiceResponse::ClientNextInputSeq(value) => value,
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn server_player_connected(self, player_id: u64) -> Option<bool> {
+        match runtime_service_call(RuntimeServiceRequest::Side(
+            RuntimeSideRequest::ServerPlayerConnected { player_id },
+        )) {
+            RuntimeServiceResponse::ServerPlayerConnected(value) => value,
+            _ => None,
+        }
+    }
+}
+
 pub struct ActionResponse;
 
 pub struct AppliedActionResponse {
-    effects: EffectBatch,
+    output: RuntimeOutput,
 }
 
-pub struct RejectedActionResponse;
+pub struct RejectedActionResponse {
+    output: RuntimeOutput,
+}
 
 impl ActionResponse {
     #[must_use]
     pub fn applied() -> AppliedActionResponse {
         AppliedActionResponse {
-            effects: EffectBatch::default(),
+            output: RuntimeOutput::default(),
         }
     }
 
     #[must_use]
     pub fn rejected() -> RejectedActionResponse {
-        RejectedActionResponse
+        RejectedActionResponse {
+            output: RuntimeOutput::default(),
+        }
     }
 }
 
 impl AppliedActionResponse {
     #[must_use]
-    pub fn push_world_effect(mut self, effect: WorldEffect) -> Self {
-        self.effects.world.push(effect);
+    pub fn push_world_command(mut self, command: WorldCommand) -> Self {
+        self.output.commands.world.push(command);
         self
     }
 
     #[must_use]
     pub fn set_block(self, pos: (i32, i32, i32), block_id: u8) -> Self {
-        self.push_world_effect(WorldEffect::SetBlock { pos, block_id })
+        self.push_world_command(WorldCommand::SetBlock {
+            pos,
+            block_id,
+            expected_old: None,
+        })
+    }
+
+    #[must_use]
+    pub fn set_block_if(self, pos: (i32, i32, i32), expected_old: u8, block_id: u8) -> Self {
+        self.push_world_command(WorldCommand::SetBlock {
+            pos,
+            block_id,
+            expected_old: Some(expected_old),
+        })
+    }
+
+    #[must_use]
+    pub fn send_client(mut self, message: ClientOutboundMessage) -> Self {
+        self.output.messages.client.push(message);
+        self
+    }
+
+    #[must_use]
+    pub fn send_server(mut self, message: ServerOutboundMessage) -> Self {
+        self.output.messages.server.push(message);
+        self
     }
 
     #[must_use]
     pub fn finish(self) -> ActionResult {
         ActionResult {
             outcome: ActionOutcome::Applied,
-            effects: self.effects,
+            output: self.output,
         }
     }
 }
 
 impl RejectedActionResponse {
     #[must_use]
+    pub fn send_client(mut self, message: ClientOutboundMessage) -> Self {
+        self.output.messages.client.push(message);
+        self
+    }
+
+    #[must_use]
+    pub fn send_server(mut self, message: ServerOutboundMessage) -> Self {
+        self.output.messages.server.push(message);
+        self
+    }
+
+    #[must_use]
     pub fn finish(self) -> ActionResult {
         ActionResult {
             outcome: ActionOutcome::Rejected,
-            effects: EffectBatch::default(),
+            output: self.output,
         }
     }
 }
@@ -515,24 +718,45 @@ impl<'a> ClientMessageContext<'a> {
     pub fn messages(&self) -> &'a [ClientInboundMessage] {
         &self.input.messages
     }
+
+    #[must_use]
+    pub fn services(&self) -> RuntimeServices {
+        RuntimeServices
+    }
 }
 
 #[derive(Default)]
 pub struct ClientMessageResponse {
-    outbound: Vec<ClientOutboundMessage>,
+    output: RuntimeOutput,
 }
 
 impl ClientMessageResponse {
     #[must_use]
     pub fn send(mut self, message: ClientOutboundMessage) -> Self {
-        self.outbound.push(message);
+        self.output.messages.client.push(message);
+        self
+    }
+
+    #[must_use]
+    pub fn send_to(mut self, message: ServerOutboundMessage) -> Self {
+        self.output.messages.server.push(message);
+        self
+    }
+
+    #[must_use]
+    pub fn set_block(mut self, pos: (i32, i32, i32), block_id: u8) -> Self {
+        self.output.commands.world.push(WorldCommand::SetBlock {
+            pos,
+            block_id,
+            expected_old: None,
+        });
         self
     }
 
     #[must_use]
     pub fn finish(self) -> ClientMessageResult {
         ClientMessageResult {
-            outbound: self.outbound,
+            output: self.output,
         }
     }
 }
@@ -556,26 +780,149 @@ impl<'a> ServerMessageContext<'a> {
     pub fn messages(&self) -> &'a [ServerInboundMessage] {
         &self.input.messages
     }
+
+    #[must_use]
+    pub fn services(&self) -> RuntimeServices {
+        RuntimeServices
+    }
 }
 
 #[derive(Default)]
 pub struct ServerMessageResponse {
-    outbound: Vec<ServerOutboundMessage>,
+    output: RuntimeOutput,
 }
 
 impl ServerMessageResponse {
     #[must_use]
     pub fn send_to(mut self, message: ServerOutboundMessage) -> Self {
-        self.outbound.push(message);
+        self.output.messages.server.push(message);
+        self
+    }
+
+    #[must_use]
+    pub fn send(mut self, message: ClientOutboundMessage) -> Self {
+        self.output.messages.client.push(message);
+        self
+    }
+
+    #[must_use]
+    pub fn set_block(mut self, pos: (i32, i32, i32), block_id: u8) -> Self {
+        self.output.commands.world.push(WorldCommand::SetBlock {
+            pos,
+            block_id,
+            expected_old: None,
+        });
         self
     }
 
     #[must_use]
     pub fn finish(self) -> ServerMessageResult {
         ServerMessageResult {
-            outbound: self.outbound,
+            output: self.output,
         }
     }
+}
+
+#[derive(Default)]
+pub struct LifecycleResponse {
+    output: RuntimeOutput,
+}
+
+impl LifecycleResponse {
+    #[must_use]
+    pub fn send(mut self, message: ClientOutboundMessage) -> Self {
+        self.output.messages.client.push(message);
+        self
+    }
+
+    #[must_use]
+    pub fn send_to(mut self, message: ServerOutboundMessage) -> Self {
+        self.output.messages.server.push(message);
+        self
+    }
+
+    #[must_use]
+    pub fn set_block(mut self, pos: (i32, i32, i32), block_id: u8) -> Self {
+        self.output.commands.world.push(WorldCommand::SetBlock {
+            pos,
+            block_id,
+            expected_old: None,
+        });
+        self
+    }
+
+    #[must_use]
+    pub fn finish(self) -> LifecycleResult {
+        LifecycleResult {
+            output: self.output,
+        }
+    }
+}
+
+fn runtime_service_call(request: RuntimeServiceRequest) -> RuntimeServiceResponse {
+    let request_bytes =
+        postcard::to_allocvec(&request).expect("runtime service request encoding must succeed");
+    let mut response = vec![0u8; 64 * 1024];
+
+    let len = if cfg!(target_arch = "wasm32") {
+        wasm_runtime_service_call(&request_bytes, &mut response)
+    } else {
+        native_runtime_service_call(&request_bytes, &mut response)
+    };
+
+    let Some(len) = len else {
+        return RuntimeServiceResponse::Unsupported;
+    };
+
+    postcard::from_bytes(&response[..len]).expect("runtime service response decoding must succeed")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn wasm_runtime_service_call(request: &[u8], response: &mut [u8]) -> Option<usize> {
+    unsafe extern "C" {
+        fn freven_guest_host_service_call(
+            req_ptr: u32,
+            req_len: u32,
+            resp_ptr: u32,
+            resp_cap: u32,
+        ) -> u32;
+    }
+
+    let req_ptr = request.as_ptr() as usize as u32;
+    let req_len = u32::try_from(request.len()).ok()?;
+    let resp_ptr = response.as_mut_ptr() as usize as u32;
+    let resp_cap = u32::try_from(response.len()).ok()?;
+    let len = unsafe { freven_guest_host_service_call(req_ptr, req_len, resp_ptr, resp_cap) };
+    if len == u32::MAX {
+        return None;
+    }
+    Some(len as usize)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn wasm_runtime_service_call(_request: &[u8], _response: &mut [u8]) -> Option<usize> {
+    None
+}
+
+fn native_runtime_service_call(request: &[u8], response: &mut [u8]) -> Option<usize> {
+    NATIVE_RUNTIME_BRIDGE.with(|bridge| {
+        let bridge = *bridge.borrow();
+        let call = bridge.call?;
+        let len = unsafe {
+            call(
+                bridge.ctx,
+                request.as_ptr(),
+                request.len(),
+                response.as_mut_ptr(),
+                response.len(),
+            )
+        };
+        if len == usize::MAX || len > response.len() {
+            None
+        } else {
+            Some(len)
+        }
+    })
 }
 
 #[doc(hidden)]
@@ -607,26 +954,26 @@ pub mod __private {
 
     fn module_start_client_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
         let input = decode_default_input::<StartInput>(input);
-        module.handle_start_client(&input);
-        encode_lifecycle_ack_bytes()
+        postcard::to_allocvec(&module.handle_start_client(&input))
+            .expect("guest encoding must succeed")
     }
 
     fn module_start_server_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
         let input = decode_default_input::<StartInput>(input);
-        module.handle_start_server(&input);
-        encode_lifecycle_ack_bytes()
+        postcard::to_allocvec(&module.handle_start_server(&input))
+            .expect("guest encoding must succeed")
     }
 
     fn module_tick_client_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
         let input = decode_required_input::<TickInput>(input);
-        module.handle_tick_client(&input);
-        encode_lifecycle_ack_bytes()
+        postcard::to_allocvec(&module.handle_tick_client(&input))
+            .expect("guest encoding must succeed")
     }
 
     fn module_tick_server_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
         let input = decode_required_input::<TickInput>(input);
-        module.handle_tick_server(&input);
-        encode_lifecycle_ack_bytes()
+        postcard::to_allocvec(&module.handle_tick_server(&input))
+            .expect("guest encoding must succeed")
     }
 
     fn module_handle_action_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
@@ -739,6 +1086,12 @@ pub mod __private {
         }
     }
 
+    pub fn native_guest_set_runtime_bridge(bridge: NativeRuntimeBridge) {
+        NATIVE_RUNTIME_BRIDGE.with(|slot| {
+            *slot.borrow_mut() = bridge;
+        });
+    }
+
     pub fn native_guest_negotiate(
         module: &GuestModule,
         input: NativeGuestInput,
@@ -831,10 +1184,6 @@ pub mod __private {
     {
         assert!(!bytes.is_empty(), "guest input must not be empty");
         postcard::from_bytes(bytes).expect("valid guest input")
-    }
-
-    fn encode_lifecycle_ack_bytes() -> Vec<u8> {
-        postcard::to_allocvec(&LifecycleAck::default()).expect("guest encoding must succeed")
     }
 
     fn with_wasm_input_bytes<R>(ptr: u32, len: u32, f: impl FnOnce(&[u8]) -> R) -> R {
@@ -1055,6 +1404,13 @@ macro_rules! export_native_guest {
         #[unsafe(no_mangle)]
         pub extern "C" fn freven_guest_dealloc(buffer: $crate::NativeGuestBuffer) {
             $crate::__private::native_guest_dealloc(buffer)
+        }
+
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_set_native_runtime_bridge(
+            bridge: $crate::NativeRuntimeBridge,
+        ) {
+            $crate::__private::native_guest_set_runtime_bridge(bridge)
         }
 
         #[unsafe(no_mangle)]
@@ -1440,8 +1796,8 @@ mod tests {
             .register_client_control_provider("freven.test:controls")
             .register_channel("freven.test:echo", message_channel())
             .declare_capability("max_call_millis")
-            .on_start_server(|_| {})
-            .on_tick_server(|_| {})
+            .on_start_server(|_| LifecycleResponse::default().finish())
+            .on_tick_server(|_| LifecycleResponse::default().finish())
             .on_server_messages(|ctx| {
                 let Some(msg) = ctx.messages().first() else {
                     return ServerMessageResponse::default();
@@ -1522,7 +1878,7 @@ mod tests {
         });
 
         assert_eq!(result.outcome, ActionOutcome::Rejected);
-        assert!(result.effects.is_empty());
+        assert!(result.output.is_empty());
     }
 
     #[test]
@@ -1539,8 +1895,8 @@ mod tests {
                 payload: b"hello".to_vec(),
             }],
         });
-        assert_eq!(result.outbound.len(), 1);
-        assert_eq!(result.outbound[0].payload, b"hello");
+        assert_eq!(result.output.messages.server.len(), 1);
+        assert_eq!(result.output.messages.server[0].payload, b"hello");
     }
 
     #[test]
@@ -1599,7 +1955,7 @@ mod tests {
     fn rejected_action_response_finishes_without_effects() {
         let result = ActionResponse::rejected().finish();
         assert_eq!(result.outcome, ActionOutcome::Rejected);
-        assert!(result.effects.is_empty());
+        assert!(result.output.is_empty());
     }
 
     #[test]
@@ -1688,8 +2044,8 @@ mod tests {
                 capability: "max_call_millis"
             }
             , lifecycle: {
-                start_server: |_| {},
-                tick_server: |_| {}
+                start_server: |_| LifecycleResponse::default().finish(),
+                tick_server: |_| LifecycleResponse::default().finish()
             }
             , server_messages: |_| ServerMessageResponse::default()
             , actions: {

--- a/docs/EXTERNAL_MOD_IPC_v1.md
+++ b/docs/EXTERNAL_MOD_IPC_v1.md
@@ -27,6 +27,8 @@ process boundary.
   - required first call after spawn
 - `negotiate`
   - payload: `request: NegotiationRequest`
+- `service_response`
+  - payload: `response: RuntimeServiceResponse`
 - `start_client`
   - payload: `input: StartInput`
 - `start_server`
@@ -46,10 +48,16 @@ process boundary.
   - payload: `protocol_version: u32`
 - `negotiate`
   - payload: `response: NegotiationResponse`
+- `service_request`
+  - payload: `request: RuntimeServiceRequest`
 - `lifecycle`
-  - payload: `ack: LifecycleAck`
+  - payload: `result: LifecycleResult`
 - `handle_action`
   - payload: `result: ActionResult`
+- `client_messages`
+  - payload: `result: ClientMessageResult`
+- `server_messages`
+  - payload: `result: ServerMessageResult`
 - `error`
   - payload: `message: String`
 
@@ -66,13 +74,19 @@ document (`ModConfigDocument`, currently TOML text).
   The runtime hosts the active side as a subset for the current session.
 - External transport supports the full `freven_guest` surface; if the guest
   declares a lifecycle hook, the companion process must answer the
-  corresponding request with a `lifecycle` response carrying `LifecycleAck`.
+  corresponding request with a `lifecycle` response carrying `LifecycleResult`.
+- A guest callback may emit one or more `service_request` envelopes before it
+  emits its terminal `lifecycle` / `handle_action` / `client_messages` /
+  `server_messages` response.
+- The host answers each `service_request` with a matching `service_response`
+  using the same envelope `id`, then continues waiting for the terminal
+  callback response.
 - If a companion process exits/crashes, disconnects, violates protocol, or times out:
   - that mod is disabled for the current runtime session
   - later lifecycle callbacks stop
   - action calls for that mod return `ActionOutcome::Rejected`
   - host kills/waits child if still alive
-- If a valid `ActionResult` cannot be completed because host-side world-effect
+- If a valid `ActionResult` cannot be completed because host-side runtime-command
   application fails, that still counts as a guest session fault:
   - the mod is disabled for the current runtime session
   - follow-up lifecycle/action calls are rejected

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -93,24 +93,25 @@ Current hosting policy:
 - Host sends `ActionInput`
 - Guest returns `ActionResult`
 - `ActionResult.outcome` is `applied` or `rejected`
-- `ActionResult.effects` currently supports world effects through `WorldEffect`
-- `ActionInput.player_position_m` is the first canonical player-read slice
+- `ActionResult.output` carries canonical runtime output families
+- rejected actions may carry message output, but must not carry command output
+- `ActionInput.player_position_m` remains an action-scoped convenience slice, not the runtime service model
 
 ## Message path
 
 - Host sends `ClientMessageInput` / `ServerMessageInput`
 - Guest returns `ClientMessageResult` / `ServerMessageResult`
-- Messaging is a dedicated callback family, separate from lifecycle and actions
+- Messaging is one canonical runtime-output family (`RuntimeOutput.messages`)
+- lifecycle, action, and message callbacks all use the same message semantics
 - outbound sends must use declared message ids and declared side-appropriate writable channels
 - inbound delivery is routed only for declared side-appropriate readable channels and declared message ids
 - unsupported/unknown message scope mapping is a guest fault, not a silent fallback
 
 ## Lifecycle path
 
-Lifecycle calls are currently ack-only.
-
 - Host sends `StartInput` or `TickInput`
-- Guest returns `LifecycleAck`
+- Guest returns `LifecycleResult`
+- `LifecycleResult.output` uses the same canonical runtime output families as actions and message callbacks
 
 `StartInput` carries:
 
@@ -122,9 +123,46 @@ Lifecycle calls are currently ack-only.
 Contract v1 currently serializes that document as TOML text with an explicit
 `ModConfigFormat`.
 
-There is intentionally no lifecycle effect/output channel in contract v1.
-Lifecycle outputs are deferred until the runtime supports a real, honest
-end-to-end lifecycle output model.
+Runtime/config/experience metadata is carried where it is semantically stable:
+
+- `StartInput.experience_id`
+- `StartInput.mod_id`
+- `StartInput.config`
+- `TickInput.tick`
+- `TickInput.dt_millis`
+
+There is intentionally no separate lifecycle-only side channel.
+
+## Runtime services
+
+Guest/runtime-loaded mods now use explicit runtime service families:
+
+- `RuntimeServiceRequest::Read(...)`
+- `RuntimeServiceRequest::Side(...)`
+- `RuntimeOutput.messages`
+- `RuntimeOutput.commands`
+
+Current read requests include:
+
+- world/block reads
+- player position reads
+- player display-name reads
+- player-to-entity resolution
+- entity component-byte reads
+
+Current side-specific requests include:
+
+- client active level
+- client next input sequence
+- server player-connected checks
+
+Current command families include:
+
+- `RuntimeCommandOutput.world`
+- `WorldCommand::SetBlock { pos, block_id, expected_old }`
+
+Transport adapters must carry these semantic families unchanged. They must not
+invent transport-specific truth about reads, messages, or command application.
 
 ## Disable-on-session semantics
 
@@ -136,7 +174,7 @@ If a guest violates the contract or faults during a runtime session:
   session
 
 For action callbacks, "faults" include host-side failure to apply the guest's
-declared world effects after the `ActionResult` is decoded and validated.
+declared runtime commands after the `ActionResult` is decoded and validated.
 
 For message callbacks, faults include invalid inbound scope mapping and
 outbound sends that violate the negotiated channel/message contract.

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -18,6 +18,8 @@ A native mod dynamic library must export these symbols:
 - `freven_guest_alloc(size: usize) -> *mut u8`
 - `freven_guest_dealloc(buffer: NativeGuestBuffer)`
 - `freven_guest_negotiate(input: NativeGuestInput) -> NativeGuestBuffer`
+- `freven_guest_set_native_runtime_bridge(bridge: NativeRuntimeBridge)` when
+  the guest wants host runtime services
 - `freven_guest_handle_action(input: NativeGuestInput) -> NativeGuestBuffer` when
   `callbacks.action = true`
 - `freven_guest_on_client_messages(input: NativeGuestInput) -> NativeGuestBuffer`
@@ -76,7 +78,7 @@ Returned bytes are postcard-encoded `freven_guest` contract types:
 - `freven_guest_handle_action` takes `ActionInput` and returns `ActionResult`
 - `freven_guest_on_client_messages` takes `ClientMessageInput` and returns `ClientMessageResult`
 - `freven_guest_on_server_messages` takes `ServerMessageInput` and returns `ServerMessageResult`
-- lifecycle exports take `StartInput` or `TickInput` and return `LifecycleAck`
+- lifecycle exports take `StartInput` or `TickInput` and return `LifecycleResult`
 
 `StartInput` carries `experience_id`, `mod_id`, and the resolved per-mod config
 document (`ModConfigDocument`, currently TOML text).
@@ -107,10 +109,23 @@ Runtime validates and enforces:
   hosting is not implemented yet
 
 On decode/validation/contract errors, attach fails.
-On lifecycle, action-call, or message contract faults, runtime disables that guest mod for the
-current runtime session and later lifecycle/action calls reject. That includes
-host-side failure to apply guest-declared world effects after a valid
-`ActionResult` returns.
+On lifecycle, action-call, or message contract faults, runtime disables that
+guest mod for the current runtime session and later lifecycle/action calls
+reject. That includes host-side failure to apply guest-declared runtime
+commands after a valid `ActionResult` returns.
+
+## Runtime services
+
+Native guests can issue canonical runtime service requests through the installed
+`NativeRuntimeBridge`.
+
+- requests use `RuntimeServiceRequest`
+- responses use `RuntimeServiceResponse`
+- runtime output still flows separately through `RuntimeOutput.messages` and
+  `RuntimeOutput.commands`
+
+The bridge is transport plumbing only. It must not redefine the semantic
+service families documented in `freven_guest`.
 
 ## Safety model
 

--- a/docs/UNSAFE_NATIVE_MODS.md
+++ b/docs/UNSAFE_NATIVE_MODS.md
@@ -67,10 +67,14 @@ Non-null zero-length buffers are invalid.
 
 `freven_guest_negotiate` returns postcard bytes for `NegotiationResponse`.
 `freven_guest_handle_action` returns postcard bytes for `ActionResult`.
-Lifecycle exports return postcard bytes for `LifecycleAck`.
+Lifecycle exports return postcard bytes for `LifecycleResult`.
 Action input bytes passed to `freven_guest_handle_action` are postcard
 `ActionInput`, which is the only authority for action binding and runtime
 action context.
+
+Native guests may also expose `freven_guest_set_native_runtime_bridge(...)` to
+receive canonical runtime service requests during lifecycle, action, or message
+callbacks.
 
 For non-empty input, the host allocates guest-owned input buffers with
 `freven_guest_alloc`, passes them by `NativeGuestInput`, and releases them with

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -12,9 +12,10 @@ recommended getting-started path.
 
 ## Scope
 
-- Supports negotiation, declaration registration, lifecycle callbacks, side-specific message callbacks, and action handling over Wasm
-  ptr/len calls.
-- Host runs modules with no WASI and no host imports by default.
+- Supports negotiation, declaration registration, lifecycle callbacks,
+  side-specific message callbacks, action handling, and runtime-service calls
+  over Wasm ptr/len calls.
+- Host runs modules with no WASI.
 - `[capabilities]` in `mod.toml` is enforced by runtime with a strict allowlist.
 
 ## Required exports
@@ -49,6 +50,14 @@ return packed `(ptr, len)` as:
 The host copies returned bytes from guest memory and then calls
 `freven_guest_dealloc(ptr, len)`.
 
+Optional runtime-service import:
+
+- `env::freven_guest_host_service_call(req_ptr, req_len, resp_ptr, resp_cap) -> u32`
+- request/response payloads are postcard-encoded `RuntimeServiceRequest` /
+  `RuntimeServiceResponse`
+- host returns `u32::MAX` when the current host context does not expose runtime
+  services
+
 ## Encoding
 
 ABI payloads are `postcard` encoded values from `freven_guest`.
@@ -72,7 +81,7 @@ Host behavior:
 
 - `freven_guest_on_start_*` input: `StartInput`
 - `freven_guest_on_tick_*` input: `TickInput`
-- lifecycle output: `LifecycleAck`
+- lifecycle output: `LifecycleResult`
 
 `StartInput` includes:
 
@@ -85,8 +94,8 @@ Host behavior:
 - `format: ModConfigFormat` (`toml`)
 - `text: String`
 
-Lifecycle is intentionally ack-only in guest contract v1. Returning any richer
-lifecycle effect payload is not part of the contract.
+Lifecycle now uses the same canonical runtime-output model as actions and
+message callbacks through `LifecycleResult.output`.
 
 ### Action input (`freven_guest_handle_action` input bytes)
 
@@ -114,23 +123,26 @@ lifecycle effect payload is not part of the contract.
 `ActionResult`:
 
 - `outcome: ActionOutcome` (`applied` or `rejected`)
-- `effects: EffectBatch`
-
-`WorldEffect` is a `postcard`-encoded Rust enum carried inside
-`EffectBatch.world`.
+- `output: RuntimeOutput`
 
 ABI rule: enum variant order is ABI-significant.
 - Do NOT reorder variants.
 - Do NOT rename variants expecting any effect on binary encoding.
 - Only append new variants at the end.
 
-Currently supported variants:
+Current command family:
 
-- `SetBlock { pos: (i32, i32, i32), block_id: u8 }`
+- `RuntimeCommandOutput.world`
+- `WorldCommand::SetBlock { pos, block_id, expected_old }`
 
-Host applies `SetBlock` effects through server world-edit APIs. Any
+Current message families:
+
+- `RuntimeMessageOutput.client`
+- `RuntimeMessageOutput.server`
+
+Host applies runtime commands through authoritative host services. Any
 decode/trap/validation/apply failure disables that guest for the runtime
-session and the action rejects.
+session.
 
 ## Capability policy (implemented in `freven_runtime_wasm`)
 
@@ -151,7 +163,7 @@ Current host policy maxima/defaults:
 - `max_negotiation_bytes`: `64 KiB`
 - `max_result_bytes`: `256 KiB`
 - `max_input_payload_bytes`: `64 KiB`
-- `max_world_effects` per action result: `128`
+- `max_world_commands` per guest callback result: `128`
 
 Capabilities may tighten selected limits (`max_call_millis`, `max_linear_memory_bytes`) but cannot raise limits above policy maxima.
 
@@ -160,7 +172,7 @@ Capabilities may tighten selected limits (`max_call_millis`, `max_linear_memory_
 - No WASI.
 - No filesystem access.
 - No network access.
-- No host function imports.
+- No host function imports beyond the explicit runtime-service bridge when used.
 
 Only required guest exports are invoked.
 
@@ -172,7 +184,7 @@ Common limits include:
 - maximum call time budget
 - maximum linear memory usage
 - maximum input payload bytes accepted from runtime to guest
-- maximum output bytes for negotiation, lifecycle, and action result payloads
+- maximum output bytes for negotiation, lifecycle, message, and action payloads
 
 Guest modules must return packed `(ptr, len)` ranges that are valid and within
 host-configured size limits. If a call exceeds limits or violates the contract,

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -26,10 +26,12 @@ The canonical guest lifecycle today is:
 - `on_server_messages`
 - action handling through one action entrypoint plus declared bindings
 
-Current contract limits:
+Current contract shape:
 
-- lifecycle hooks are ack-only in guest contract v1
-- lifecycle callbacks do not return effect batches yet
+- lifecycle hooks return `LifecycleResult`
+- action callbacks return `ActionResult`
+- message callbacks return `ClientMessageResult` / `ServerMessageResult`
+- all three callback families emit the same `RuntimeOutput` families
 - `on_start_common` is not part of the runtime-loaded guest contract
 
 Those boundaries are intentional. The SDK does not pretend lifecycle output or
@@ -79,7 +81,7 @@ What stays explicit:
 - declared lifecycle hooks
 - declared action bindings
 - exported Wasm capability surface generated from that same declaration
-- canonical action result semantics and world effects
+- canonical runtime output semantics and authoritative world commands
 
 `wasm_guest!` is intentionally declarative rather than magical. The lifecycle
 hooks and action bindings you write are the same data used to build the
@@ -110,13 +112,14 @@ not the recommended public authoring path.
 - `decode_payload::<T>()`
 
 Use `ActionResponse::applied()` or `ActionResponse::rejected()` to surface the
-canonical outcome, then attach effects such as `.set_block(...)`.
+canonical outcome, then attach runtime output such as `.set_block(...)` or
+message sends.
 
 Two SDK hardening rules matter here:
 
 - `ActionResponse::rejected()` is terminal at the API level:
   the rejected response builder can be finished, but it does not expose
-  world-effect builder methods.
+  authoritative-command builder methods.
 - Action callbacks require a real decoded `ActionInput`; empty or malformed
   action payload bytes are not silently synthesized by the SDK.
   In practice this means a contract / transport / host-delivery violation on
@@ -135,6 +138,18 @@ The config document is the resolved per-mod `experience.config."<mod_id>"`
 table serialized as TOML text. `freven_guest_sdk::StartInputExt` exposes
 `config_text()` and `config_typed::<T>()` helpers so guest authors can read the
 same per-mod config semantics compile-time mods already had.
+
+## Runtime services
+
+`freven_guest_sdk` exposes `RuntimeServices` for runtime-loaded guests:
+
+- reads: `block_world`, `player_position`, `player_display_name`,
+  `player_entity_id`, `entity_component_bytes`
+- side-specific facilities: `client_active_level`, `client_next_input_seq`,
+  `server_player_connected`
+
+These calls are semantic runtime services. They are not ad-hoc callback hacks
+and they are not encoded as fake action results.
 
 ## Transport guidance
 


### PR DESCRIPTION
## Summary
This PR introduces the canonical guest runtime service model in `freven-sdk`.

It extends the public guest contract with explicit runtime service requests and runtime output families, replaces the older lifecycle acknowledgement shape with `LifecycleResult`, and aligns the SDK helpers and docs around one transport-agnostic model for runtime-loaded mods.

## What changed
- added canonical runtime service requests to the public guest contract
- introduced canonical runtime output families for guest execution
- replaced lifecycle acknowledgements with `LifecycleResult`
- updated `freven_guest_sdk` with transport-agnostic service helpers
- aligned `freven_api` with the new guest runtime service model
- refreshed ABI, IPC, unsafe native, and authoring documentation

## Why
This gives guest authors and runtime hosts one shared semantic contract for:
- lifecycle callbacks
- message callbacks
- runtime service requests
- runtime-declared outputs and commands

That makes the SDK surface clearer, more consistent across transports, and easier to evolve without reintroducing transport-specific semantics into the public API.