### PR TITLE
Expand the canonical guest contract for providers and runtime services

### DIFF
--- a/crates/freven_api/README.md
+++ b/crates/freven_api/README.md
@@ -22,8 +22,8 @@ For runtime-loaded guests, the canonical public contract lives in
 `freven_api` is the compile-time facade over that same canonical declaration
 model by breadth. Provider families such as worldgen, character controllers,
 and client control providers are no longer compile-time-only secret semantics;
-they exist canonically in `freven_guest` even when a runtime guest execution
-policy still gates hosting for them.
+they exist canonically in `freven_guest`, and runtime guest execution either
+hosts them through the same model or gates them explicitly by policy.
 
 ## Stability and semver stance
 

--- a/crates/freven_api/src/lib.rs
+++ b/crates/freven_api/src/lib.rs
@@ -17,12 +17,15 @@ use serde::de::DeserializeOwned;
 
 pub use freven_guest::{
     CharacterControllerDeclaration, ClientControlProviderDeclaration,
-    GuestCallbacks as ModCallbackModel, GuestRegistration as ModDeclarationModel,
-    LifecycleHooks as LifecycleCallbackModel, MessageHooks as MessageCallbackModel,
-    ModConfigDocument as GuestModConfigDocument, ModConfigFormat as GuestModConfigFormat,
-    RuntimeCommandOutput, RuntimeEntityTarget, RuntimeLevelRef, RuntimeOutput, RuntimeReadRequest,
-    RuntimeServiceRequest, RuntimeServiceResponse, RuntimeSideRequest, WorldCommand,
-    WorldGenDeclaration,
+    ClientNameplateDrawCmd as GuestClientNameplateDrawCmd,
+    ClientPlayerView as GuestClientPlayerView, GuestCallbacks as ModCallbackModel,
+    GuestRegistration as ModDeclarationModel, LifecycleHooks as LifecycleCallbackModel,
+    MessageHooks as MessageCallbackModel, ModConfigDocument as GuestModConfigDocument,
+    ModConfigFormat as GuestModConfigFormat, ProviderHooks as ProviderCallbackModel,
+    RuntimeCharacterPhysicsRequest, RuntimeClientControlRequest, RuntimeCommandOutput,
+    RuntimeEntityTarget, RuntimeLevelRef, RuntimeOutput, RuntimePresentationOutput,
+    RuntimeReadRequest, RuntimeServiceRequest, RuntimeServiceResponse, RuntimeSideRequest,
+    WorldCommand, WorldGenDeclaration,
 };
 pub use freven_sdk_types::blocks::{BlockDef, BlockRuntimeId, RenderLayer};
 pub use freven_sdk_types::{blocks, voxel};
@@ -325,25 +328,33 @@ impl<'a> ModContext<'a> {
     pub fn register_worldgen(
         &mut self,
         key: &str,
-        factory: WorldGenFactory,
+        factory: impl Fn(WorldGenInit) -> Box<dyn WorldGenProvider> + Send + Sync + 'static,
     ) -> Result<WorldGenId, ModRegistrationError> {
-        self.backend.register_worldgen(key, factory)
+        self.backend.register_worldgen(key, Arc::new(factory))
     }
 
     pub fn register_character_controller(
         &mut self,
         key: &str,
-        factory: CharacterControllerFactory,
+        factory: impl Fn(CharacterControllerInit) -> Box<dyn CharacterController>
+        + Send
+        + Sync
+        + 'static,
     ) -> Result<CharacterControllerId, ModRegistrationError> {
-        self.backend.register_character_controller(key, factory)
+        self.backend
+            .register_character_controller(key, Arc::new(factory))
     }
 
     pub fn register_client_control_provider(
         &mut self,
         key: &str,
-        factory: ClientControlProviderFactory,
+        factory: impl Fn(ClientControlProviderInit) -> Box<dyn ClientControlProvider>
+        + Send
+        + Sync
+        + 'static,
     ) -> Result<ClientControlProviderId, ModRegistrationError> {
-        self.backend.register_client_control_provider(key, factory)
+        self.backend
+            .register_client_control_provider(key, Arc::new(factory))
     }
 
     pub fn register_channel(
@@ -545,6 +556,19 @@ pub trait Services {
             Ok(())
         } else {
             Err(RuntimeOutputApplyError::UnsupportedFamily { family: "commands" })
+        }
+    }
+
+    fn apply_guest_runtime_presentation(
+        &mut self,
+        presentation: &RuntimePresentationOutput,
+    ) -> Result<(), RuntimeOutputApplyError> {
+        if presentation.is_empty() {
+            Ok(())
+        } else {
+            Err(RuntimeOutputApplyError::UnsupportedFamily {
+                family: "presentation",
+            })
         }
     }
 }
@@ -1138,7 +1162,7 @@ impl WorldGenInit {
 }
 
 /// Worldgen provider factory. One provider instance can be created per world/session.
-pub type WorldGenFactory = fn(WorldGenInit) -> Box<dyn WorldGenProvider>;
+pub type WorldGenFactory = Arc<dyn Fn(WorldGenInit) -> Box<dyn WorldGenProvider> + Send + Sync>;
 
 /// Minimal worldgen request contract placeholder.
 #[derive(Debug, Default, Clone)]
@@ -1398,11 +1422,12 @@ pub trait CharacterController: Send + Sync {
 pub struct CharacterControllerInit {}
 
 /// Character controller factory.
-pub type CharacterControllerFactory = fn(CharacterControllerInit) -> Box<dyn CharacterController>;
+pub type CharacterControllerFactory =
+    Arc<dyn Fn(CharacterControllerInit) -> Box<dyn CharacterController> + Send + Sync>;
 
 /// Client control provider factory.
 pub type ClientControlProviderFactory =
-    fn(ClientControlProviderInit) -> Box<dyn ClientControlProvider>;
+    Arc<dyn Fn(ClientControlProviderInit) -> Box<dyn ClientControlProvider> + Send + Sync>;
 
 /// Channel reliability policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/freven_guest/src/lib.rs
+++ b/crates/freven_guest/src/lib.rs
@@ -118,6 +118,7 @@ pub struct GuestCallbacks {
     pub lifecycle: LifecycleHooks,
     pub action: bool,
     pub messages: MessageHooks,
+    pub providers: ProviderHooks,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -132,6 +133,13 @@ pub struct LifecycleHooks {
 pub struct MessageHooks {
     pub client: bool,
     pub server: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderHooks {
+    pub worldgen: bool,
+    pub character_controller: bool,
+    pub client_control_provider: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -232,6 +240,126 @@ pub struct CapabilityDeclaration {
     pub key: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorldGenCallInput {
+    pub key: String,
+    pub init: WorldGenInit,
+    pub request: WorldGenRequest,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct WorldGenCallResult {
+    pub output: WorldGenOutput,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct WorldGenInit {
+    pub seed: u64,
+    pub world_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct WorldGenRequest {
+    pub seed: u64,
+    pub cx: i32,
+    pub cz: i32,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct WorldGenOutput {
+    pub sections: Vec<WorldGenSection>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorldGenSection {
+    pub sy: i8,
+    pub blocks: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CharacterControllerInitInput {
+    pub key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CharacterControllerInitResult {
+    pub config: CharacterConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CharacterControllerStepInput {
+    pub key: String,
+    pub state: CharacterState,
+    pub input: CharacterControllerInput,
+    pub dt_millis: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CharacterControllerStepResult {
+    pub state: CharacterState,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CharacterShape {
+    Aabb { half_extents: [f32; 3] },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct CharacterConfig {
+    pub shape: CharacterShape,
+    pub max_speed_ground: f32,
+    pub max_speed_air: f32,
+    pub accel_ground: f32,
+    pub accel_air: f32,
+    pub gravity: f32,
+    pub jump_impulse: f32,
+    pub step_height: f32,
+    pub skin_width: f32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct CharacterState {
+    pub pos: [f32; 3],
+    pub vel: [f32; 3],
+    pub on_ground: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CharacterControllerInput {
+    pub input: Vec<u8>,
+    pub view_yaw_deg_mdeg: i32,
+    pub view_pitch_deg_mdeg: i32,
+    pub timeline: InputTimeline,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InputTimeline {
+    pub input_seq: u32,
+    pub sim_tick: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientControlSampleInput {
+    pub key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientControlSampleResult {
+    pub output: ClientControlOutput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientControlOutput {
+    pub input: Vec<u8>,
+    pub view_yaw_deg_mdeg: i32,
+    pub view_pitch_deg_mdeg: i32,
+}
+
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ModConfigFormat {
@@ -323,12 +451,13 @@ pub enum ActionOutcome {
 pub struct RuntimeOutput {
     pub messages: RuntimeMessageOutput,
     pub commands: RuntimeCommandOutput,
+    pub presentation: RuntimePresentationOutput,
 }
 
 impl RuntimeOutput {
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.messages.is_empty() && self.commands.is_empty()
+        self.messages.is_empty() && self.commands.is_empty() && self.presentation.is_empty()
     }
 }
 
@@ -356,6 +485,19 @@ impl RuntimeCommandOutput {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.world.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct RuntimePresentationOutput {
+    pub nameplates: Vec<ClientNameplateDrawCmd>,
+}
+
+impl RuntimePresentationOutput {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.nameplates.is_empty()
     }
 }
 
@@ -426,13 +568,77 @@ pub struct RuntimeLevelRef {
     pub stream_epoch: u32,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct ClientPlayerView {
+    pub player_id: u64,
+    pub world_pos_m: (f32, f32, f32),
+    pub is_local: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientNameplateDrawCmd {
+    pub text: String,
+    pub screen_pos_px: (i32, i32),
+    pub rgba: (u8, u8, u8, u8),
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientMouseButton {
+    Left,
+    Right,
+    Middle,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientKeyCode {
+    KeyW,
+    KeyA,
+    KeyS,
+    KeyD,
+    KeyE,
+    KeyQ,
+    Space,
+    Shift,
+    Ctrl,
+    Escape,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct KinematicMoveConfig {
+    pub skin_width: f32,
+    pub contact_epsilon: f32,
+    pub max_substeps: u8,
+    pub max_motion_per_step: f32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct SweepHit {
+    pub hit: bool,
+    pub toi: f32,
+    pub normal: [f32; 3],
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct KinematicMoveResult {
+    pub pos: [f32; 3],
+    pub applied_motion: [f32; 3],
+    pub hit_x: bool,
+    pub hit_y: bool,
+    pub hit_z: bool,
+    pub hit_ground: bool,
+    pub started_overlapping: bool,
+    pub collision_incomplete: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum RuntimeEntityTarget {
     Player { player_id: u64 },
     Entity { entity_id: u32 },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum RuntimeReadRequest {
     WorldBlock {
         pos: (i32, i32, i32),
@@ -450,6 +656,10 @@ pub enum RuntimeReadRequest {
         entity: RuntimeEntityTarget,
         component_key: String,
     },
+    ClientPlayerViews,
+    ClientWorldToScreen {
+        world_pos_m: (f32, f32, f32),
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -460,9 +670,54 @@ pub enum RuntimeSideRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RuntimeClientControlRequest {
+    BindMouseButton {
+        button: ClientMouseButton,
+        owner: String,
+    },
+    BindKey {
+        key: ClientKeyCode,
+        owner: String,
+    },
+    MouseButtonDown {
+        button: ClientMouseButton,
+        owner: String,
+    },
+    KeyDown {
+        key: ClientKeyCode,
+        owner: String,
+    },
+    MouseDelta,
+    CursorLocked,
+    ViewAnglesDegMdeg,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum RuntimeCharacterPhysicsRequest {
+    IsSolidWorldCollision {
+        wx: i32,
+        wy: i32,
+        wz: i32,
+    },
+    SweepAabb {
+        half_extents: [f32; 3],
+        from: [f32; 3],
+        to: [f32; 3],
+    },
+    MoveAabbTerrain {
+        half_extents: [f32; 3],
+        pos: [f32; 3],
+        motion: [f32; 3],
+        cfg: KinematicMoveConfig,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum RuntimeServiceRequest {
     Read(RuntimeReadRequest),
     Side(RuntimeSideRequest),
+    ClientControl(RuntimeClientControlRequest),
+    CharacterPhysics(RuntimeCharacterPhysicsRequest),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -472,8 +727,16 @@ pub enum RuntimeServiceResponse {
     PlayerDisplayName(Option<String>),
     PlayerEntityId(Option<u32>),
     EntityComponentBytes(Option<Vec<u8>>),
+    ClientPlayerViews(Vec<ClientPlayerView>),
+    ClientWorldToScreen(Option<(i32, i32)>),
     ClientActiveLevel(Option<RuntimeLevelRef>),
     ClientNextInputSeq(Option<u32>),
     ServerPlayerConnected(Option<bool>),
+    ClientControlBool(bool),
+    ClientControlMouseDelta((i32, i32)),
+    ClientControlViewAnglesDegMdeg((i32, i32)),
+    CharacterPhysicsIsSolidWorldCollision(bool),
+    CharacterPhysicsSweepAabb(SweepHit),
+    CharacterPhysicsMoveAabbTerrain(KinematicMoveResult),
     Unsupported,
 }

--- a/crates/freven_guest_sdk/README.md
+++ b/crates/freven_guest_sdk/README.md
@@ -78,9 +78,11 @@ intentionally need to wire the raw surface yourself.
   config document for the guest path.
 - Capability declarations are validated honestly by the runtime:
   empty keys fail, and unknown capability keys are rejected against host policy.
-- Provider families are declared honestly but remain runtime-policy-gated for
-  guest transports today: guests can declare those keys, and the host will
-  reject them explicitly until provider hosting exists.
+- Provider families use the same canonical declaration model as builtin mods.
+  Wasm and native guests can now host `worldgen`, `character_controllers`, and
+  `client_control_providers`; transports that cannot support a family for a
+  given execution/policy class must still declare it canonically and are gated
+  explicitly by host policy.
 - Guest-side persistent instance state is not modeled by the SDK today. Use
   explicit statics only when you fully control the implications.
 - Wasm is the primary safe path. Native and external transports remain

--- a/crates/freven_guest_sdk/src/lib.rs
+++ b/crates/freven_guest_sdk/src/lib.rs
@@ -8,18 +8,24 @@ use core::cell::RefCell;
 pub use freven_guest::{
     ActionDeclaration, ActionInput, ActionOutcome, ActionResult, BlockDeclaration,
     CapabilityDeclaration, ChannelBudget, ChannelConfig, ChannelDeclaration, ChannelDirection,
-    ChannelOrdering, ChannelReliability, CharacterControllerDeclaration,
-    ClientControlProviderDeclaration, ClientInboundMessage, ClientMessageInput,
-    ClientMessageResult, ClientOutboundMessage, ClientOutboundMessageScope, ComponentCodec,
-    ComponentDeclaration, GUEST_CONTRACT_VERSION_1, GuestCallbacks, GuestDescription,
-    GuestRegistration, GuestTransport, LifecycleHooks, LifecycleResult, MessageCodec,
-    MessageDeclaration, MessageHooks, MessageScope, ModConfigDocument, ModConfigFormat,
-    NativeGuestBuffer, NativeGuestInput, NativeRuntimeBridge, NegotiationRequest,
-    NegotiationResponse, RuntimeCommandOutput, RuntimeEntityTarget, RuntimeLevelRef,
-    RuntimeMessageOutput, RuntimeOutput, RuntimeReadRequest, RuntimeServiceRequest,
-    RuntimeServiceResponse, RuntimeSideRequest, ServerInboundMessage, ServerMessageInput,
-    ServerMessageResult, ServerOutboundMessage, StartInput, TickInput, WorldCommand,
-    WorldGenDeclaration,
+    ChannelOrdering, ChannelReliability, CharacterConfig, CharacterControllerDeclaration,
+    CharacterControllerInitInput, CharacterControllerInitResult, CharacterControllerInput,
+    CharacterControllerStepInput, CharacterControllerStepResult, CharacterShape, CharacterState,
+    ClientControlOutput, ClientControlProviderDeclaration, ClientControlSampleInput,
+    ClientControlSampleResult, ClientInboundMessage, ClientKeyCode, ClientMessageInput,
+    ClientMessageResult, ClientMouseButton, ClientNameplateDrawCmd, ClientOutboundMessage,
+    ClientOutboundMessageScope, ClientPlayerView, ComponentCodec, ComponentDeclaration,
+    GUEST_CONTRACT_VERSION_1, GuestCallbacks, GuestDescription, GuestRegistration, GuestTransport,
+    InputTimeline, KinematicMoveConfig, KinematicMoveResult, LifecycleHooks, LifecycleResult,
+    MessageCodec, MessageDeclaration, MessageHooks, MessageScope, ModConfigDocument,
+    ModConfigFormat, NativeGuestBuffer, NativeGuestInput, NativeRuntimeBridge, NegotiationRequest,
+    NegotiationResponse, ProviderHooks, RuntimeCharacterPhysicsRequest,
+    RuntimeClientControlRequest, RuntimeCommandOutput, RuntimeEntityTarget, RuntimeLevelRef,
+    RuntimeMessageOutput, RuntimeOutput, RuntimePresentationOutput, RuntimeReadRequest,
+    RuntimeServiceRequest, RuntimeServiceResponse, RuntimeSideRequest, ServerInboundMessage,
+    ServerMessageInput, ServerMessageResult, ServerOutboundMessage, StartInput, SweepHit,
+    TickInput, WorldCommand, WorldGenCallInput, WorldGenCallResult, WorldGenDeclaration,
+    WorldGenInit, WorldGenOutput, WorldGenRequest, WorldGenSection,
 };
 pub use freven_sdk_types::blocks::{BlockDef, RenderLayer};
 use serde::de::DeserializeOwned;
@@ -29,6 +35,13 @@ type TickHandler = fn(TickContext<'_>) -> LifecycleResult;
 type ActionHandler = fn(ActionContext<'_>) -> ActionResult;
 type ClientMessageHandler = fn(ClientMessageContext<'_>) -> ClientMessageResponse;
 type ServerMessageHandler = fn(ServerMessageContext<'_>) -> ServerMessageResponse;
+type WorldGenHandler = fn(WorldGenContext<'_>) -> WorldGenCallResult;
+type CharacterControllerInitHandler =
+    fn(CharacterControllerInitContext<'_>) -> CharacterControllerInitResult;
+type CharacterControllerStepHandler =
+    fn(CharacterControllerStepContext<'_>) -> CharacterControllerStepResult;
+type ClientControlProviderHandler =
+    fn(ClientControlProviderContext<'_>) -> ClientControlSampleResult;
 
 thread_local! {
     static NATIVE_RUNTIME_BRIDGE: RefCell<NativeRuntimeBridge> =
@@ -43,6 +56,9 @@ pub struct GuestModule {
     worldgen: Vec<WorldGenDeclaration>,
     character_controllers: Vec<CharacterControllerDeclaration>,
     client_control_providers: Vec<ClientControlProviderDeclaration>,
+    worldgen_handlers: Vec<GuestWorldGen>,
+    character_controller_handlers: Vec<GuestCharacterController>,
+    client_control_provider_handlers: Vec<GuestClientControlProvider>,
     channels: Vec<ChannelDeclaration>,
     actions: Vec<GuestAction>,
     capabilities: Vec<CapabilityDeclaration>,
@@ -69,6 +85,9 @@ impl GuestModule {
             worldgen: Vec::new(),
             character_controllers: Vec::new(),
             client_control_providers: Vec::new(),
+            worldgen_handlers: Vec::new(),
+            character_controller_handlers: Vec::new(),
+            client_control_provider_handlers: Vec::new(),
             channels: Vec::new(),
             actions: Vec::new(),
             capabilities: Vec::new(),
@@ -137,6 +156,17 @@ impl GuestModule {
     }
 
     #[must_use]
+    pub fn register_worldgen_handler(
+        mut self,
+        key: &'static str,
+        handler: WorldGenHandler,
+    ) -> Self {
+        self = self.register_worldgen(key);
+        self.worldgen_handlers.push(GuestWorldGen { key, handler });
+        self
+    }
+
+    #[must_use]
     pub fn register_character_controller(mut self, key: &'static str) -> Self {
         assert_unique_key(
             "character_controller",
@@ -153,6 +183,19 @@ impl GuestModule {
     }
 
     #[must_use]
+    pub fn register_character_controller_handler(
+        mut self,
+        key: &'static str,
+        init: CharacterControllerInitHandler,
+        step: CharacterControllerStepHandler,
+    ) -> Self {
+        self = self.register_character_controller(key);
+        self.character_controller_handlers
+            .push(GuestCharacterController { key, init, step });
+        self
+    }
+
+    #[must_use]
     pub fn register_client_control_provider(mut self, key: &'static str) -> Self {
         assert_unique_key(
             "client_control_provider",
@@ -165,6 +208,18 @@ impl GuestModule {
             .push(ClientControlProviderDeclaration {
                 key: key.to_string(),
             });
+        self
+    }
+
+    #[must_use]
+    pub fn register_client_control_provider_handler(
+        mut self,
+        key: &'static str,
+        handler: ClientControlProviderHandler,
+    ) -> Self {
+        self = self.register_client_control_provider(key);
+        self.client_control_provider_handlers
+            .push(GuestClientControlProvider { key, handler });
         self
     }
 
@@ -272,6 +327,11 @@ impl GuestModule {
                 client: self.on_client_messages.is_some(),
                 server: self.on_server_messages.is_some(),
             },
+            providers: ProviderHooks {
+                worldgen: !self.worldgen_handlers.is_empty(),
+                character_controller: !self.character_controller_handlers.is_empty(),
+                client_control_provider: !self.client_control_provider_handlers.is_empty(),
+            },
         }
     }
 
@@ -357,6 +417,69 @@ impl GuestModule {
         };
         handler(ServerMessageContext { input: &input }).finish()
     }
+
+    #[must_use]
+    pub fn handle_worldgen(&self, input: WorldGenCallInput) -> WorldGenCallResult {
+        let Some(entry) = self
+            .worldgen_handlers
+            .iter()
+            .find(|entry| entry.key == input.key)
+        else {
+            return WorldGenCallResult::default();
+        };
+        (entry.handler)(WorldGenContext { input: &input })
+    }
+
+    #[must_use]
+    pub fn handle_character_controller_init(
+        &self,
+        input: CharacterControllerInitInput,
+    ) -> CharacterControllerInitResult {
+        let Some(entry) = self
+            .character_controller_handlers
+            .iter()
+            .find(|entry| entry.key == input.key)
+        else {
+            panic!("freven_guest_sdk character controller init called for undeclared key");
+        };
+        (entry.init)(CharacterControllerInitContext { input: &input })
+    }
+
+    #[must_use]
+    pub fn handle_character_controller_step(
+        &self,
+        input: CharacterControllerStepInput,
+    ) -> CharacterControllerStepResult {
+        let Some(entry) = self
+            .character_controller_handlers
+            .iter()
+            .find(|entry| entry.key == input.key)
+        else {
+            return CharacterControllerStepResult { state: input.state };
+        };
+        (entry.step)(CharacterControllerStepContext { input: &input })
+    }
+
+    #[must_use]
+    pub fn handle_client_control_provider(
+        &self,
+        input: ClientControlSampleInput,
+    ) -> ClientControlSampleResult {
+        let Some(entry) = self
+            .client_control_provider_handlers
+            .iter()
+            .find(|entry| entry.key == input.key)
+        else {
+            return ClientControlSampleResult {
+                output: ClientControlOutput {
+                    input: Vec::new(),
+                    view_yaw_deg_mdeg: 0,
+                    view_pitch_deg_mdeg: 0,
+                },
+            };
+        };
+        (entry.handler)(ClientControlProviderContext { input: &input })
+    }
 }
 
 fn assert_unique_key<'a>(kind: &str, key: &'static str, existing: impl Iterator<Item = &'a str>) {
@@ -374,6 +497,22 @@ struct GuestAction {
     key: &'static str,
     binding_id: u32,
     handler: ActionHandler,
+}
+
+struct GuestWorldGen {
+    key: &'static str,
+    handler: WorldGenHandler,
+}
+
+struct GuestCharacterController {
+    key: &'static str,
+    init: CharacterControllerInitHandler,
+    step: CharacterControllerStepHandler,
+}
+
+struct GuestClientControlProvider {
+    key: &'static str,
+    handler: ClientControlProviderHandler,
 }
 
 pub struct ActionContext<'a> {
@@ -431,6 +570,105 @@ impl<'a> ActionContext<'a> {
         T: DeserializeOwned,
     {
         postcard::from_bytes(self.input.payload)
+    }
+
+    #[must_use]
+    pub fn services(&self) -> RuntimeServices {
+        RuntimeServices
+    }
+}
+
+pub struct WorldGenContext<'a> {
+    input: &'a WorldGenCallInput,
+}
+
+impl<'a> WorldGenContext<'a> {
+    #[must_use]
+    pub fn input(&self) -> &'a WorldGenCallInput {
+        self.input
+    }
+
+    #[must_use]
+    pub fn key(&self) -> &'a str {
+        &self.input.key
+    }
+
+    #[must_use]
+    pub fn init(&self) -> &'a WorldGenInit {
+        &self.input.init
+    }
+
+    #[must_use]
+    pub fn request(&self) -> &'a WorldGenRequest {
+        &self.input.request
+    }
+}
+
+pub struct CharacterControllerInitContext<'a> {
+    input: &'a CharacterControllerInitInput,
+}
+
+impl<'a> CharacterControllerInitContext<'a> {
+    #[must_use]
+    pub fn input(&self) -> &'a CharacterControllerInitInput {
+        self.input
+    }
+
+    #[must_use]
+    pub fn key(&self) -> &'a str {
+        &self.input.key
+    }
+}
+
+pub struct CharacterControllerStepContext<'a> {
+    input: &'a CharacterControllerStepInput,
+}
+
+impl<'a> CharacterControllerStepContext<'a> {
+    #[must_use]
+    pub fn input(&self) -> &'a CharacterControllerStepInput {
+        self.input
+    }
+
+    #[must_use]
+    pub fn key(&self) -> &'a str {
+        &self.input.key
+    }
+
+    #[must_use]
+    pub fn state(&self) -> CharacterState {
+        self.input.state
+    }
+
+    #[must_use]
+    pub fn controller_input(&self) -> &'a CharacterControllerInput {
+        &self.input.input
+    }
+
+    #[must_use]
+    pub fn dt_millis(&self) -> u32 {
+        self.input.dt_millis
+    }
+
+    #[must_use]
+    pub fn services(&self) -> RuntimeServices {
+        RuntimeServices
+    }
+}
+
+pub struct ClientControlProviderContext<'a> {
+    input: &'a ClientControlSampleInput,
+}
+
+impl<'a> ClientControlProviderContext<'a> {
+    #[must_use]
+    pub fn input(&self) -> &'a ClientControlSampleInput {
+        self.input
+    }
+
+    #[must_use]
+    pub fn key(&self) -> &'a str {
+        &self.input.key
     }
 
     #[must_use]
@@ -575,6 +813,26 @@ impl RuntimeServices {
     }
 
     #[must_use]
+    pub fn client_player_views(self) -> Vec<ClientPlayerView> {
+        match runtime_service_call(RuntimeServiceRequest::Read(
+            RuntimeReadRequest::ClientPlayerViews,
+        )) {
+            RuntimeServiceResponse::ClientPlayerViews(value) => value,
+            _ => Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn client_world_to_screen(self, world_pos_m: (f32, f32, f32)) -> Option<(i32, i32)> {
+        match runtime_service_call(RuntimeServiceRequest::Read(
+            RuntimeReadRequest::ClientWorldToScreen { world_pos_m },
+        )) {
+            RuntimeServiceResponse::ClientWorldToScreen(value) => value,
+            _ => None,
+        }
+    }
+
+    #[must_use]
     pub fn client_active_level(self) -> Option<RuntimeLevelRef> {
         match runtime_service_call(RuntimeServiceRequest::Side(
             RuntimeSideRequest::ClientActiveLevel,
@@ -601,6 +859,146 @@ impl RuntimeServices {
         )) {
             RuntimeServiceResponse::ServerPlayerConnected(value) => value,
             _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn bind_mouse_button(self, button: ClientMouseButton, owner: &str) -> bool {
+        matches!(
+            runtime_service_call(RuntimeServiceRequest::ClientControl(
+                RuntimeClientControlRequest::BindMouseButton {
+                    button,
+                    owner: owner.to_string(),
+                },
+            )),
+            RuntimeServiceResponse::ClientControlBool(true)
+        )
+    }
+
+    #[must_use]
+    pub fn bind_key(self, key: ClientKeyCode, owner: &str) -> bool {
+        matches!(
+            runtime_service_call(RuntimeServiceRequest::ClientControl(
+                RuntimeClientControlRequest::BindKey {
+                    key,
+                    owner: owner.to_string(),
+                },
+            )),
+            RuntimeServiceResponse::ClientControlBool(true)
+        )
+    }
+
+    #[must_use]
+    pub fn mouse_button_down(self, button: ClientMouseButton, owner: &str) -> bool {
+        matches!(
+            runtime_service_call(RuntimeServiceRequest::ClientControl(
+                RuntimeClientControlRequest::MouseButtonDown {
+                    button,
+                    owner: owner.to_string(),
+                },
+            )),
+            RuntimeServiceResponse::ClientControlBool(true)
+        )
+    }
+
+    #[must_use]
+    pub fn key_down(self, key: ClientKeyCode, owner: &str) -> bool {
+        matches!(
+            runtime_service_call(RuntimeServiceRequest::ClientControl(
+                RuntimeClientControlRequest::KeyDown {
+                    key,
+                    owner: owner.to_string(),
+                },
+            )),
+            RuntimeServiceResponse::ClientControlBool(true)
+        )
+    }
+
+    #[must_use]
+    pub fn mouse_delta(self) -> (i32, i32) {
+        match runtime_service_call(RuntimeServiceRequest::ClientControl(
+            RuntimeClientControlRequest::MouseDelta,
+        )) {
+            RuntimeServiceResponse::ClientControlMouseDelta(value) => value,
+            _ => (0, 0),
+        }
+    }
+
+    #[must_use]
+    pub fn cursor_locked(self) -> bool {
+        matches!(
+            runtime_service_call(RuntimeServiceRequest::ClientControl(
+                RuntimeClientControlRequest::CursorLocked,
+            )),
+            RuntimeServiceResponse::ClientControlBool(true)
+        )
+    }
+
+    #[must_use]
+    pub fn view_angles_deg_mdeg(self) -> (i32, i32) {
+        match runtime_service_call(RuntimeServiceRequest::ClientControl(
+            RuntimeClientControlRequest::ViewAnglesDegMdeg,
+        )) {
+            RuntimeServiceResponse::ClientControlViewAnglesDegMdeg(value) => value,
+            _ => (0, 0),
+        }
+    }
+
+    #[must_use]
+    pub fn is_solid_world_collision(self, wx: i32, wy: i32, wz: i32) -> bool {
+        matches!(
+            runtime_service_call(RuntimeServiceRequest::CharacterPhysics(
+                RuntimeCharacterPhysicsRequest::IsSolidWorldCollision { wx, wy, wz },
+            )),
+            RuntimeServiceResponse::CharacterPhysicsIsSolidWorldCollision(true)
+        )
+    }
+
+    #[must_use]
+    pub fn sweep_aabb(self, half_extents: [f32; 3], from: [f32; 3], to: [f32; 3]) -> SweepHit {
+        match runtime_service_call(RuntimeServiceRequest::CharacterPhysics(
+            RuntimeCharacterPhysicsRequest::SweepAabb {
+                half_extents,
+                from,
+                to,
+            },
+        )) {
+            RuntimeServiceResponse::CharacterPhysicsSweepAabb(value) => value,
+            _ => SweepHit {
+                hit: false,
+                toi: 1.0,
+                normal: [0.0, 0.0, 0.0],
+            },
+        }
+    }
+
+    #[must_use]
+    pub fn move_aabb_terrain(
+        self,
+        half_extents: [f32; 3],
+        pos: [f32; 3],
+        motion: [f32; 3],
+        cfg: KinematicMoveConfig,
+    ) -> KinematicMoveResult {
+        match runtime_service_call(RuntimeServiceRequest::CharacterPhysics(
+            RuntimeCharacterPhysicsRequest::MoveAabbTerrain {
+                half_extents,
+                pos,
+                motion,
+                cfg,
+            },
+        )) {
+            RuntimeServiceResponse::CharacterPhysicsMoveAabbTerrain(value) => value,
+            _ => KinematicMoveResult {
+                pos,
+                applied_motion: [0.0, 0.0, 0.0],
+                hit_x: false,
+                hit_y: false,
+                hit_z: false,
+                hit_ground: false,
+                started_overlapping: false,
+                collision_incomplete: true,
+            },
         }
     }
 }
@@ -754,6 +1152,12 @@ impl ClientMessageResponse {
     }
 
     #[must_use]
+    pub fn push_nameplate(mut self, cmd: ClientNameplateDrawCmd) -> Self {
+        self.output.presentation.nameplates.push(cmd);
+        self
+    }
+
+    #[must_use]
     pub fn finish(self) -> ClientMessageResult {
         ClientMessageResult {
             output: self.output,
@@ -816,6 +1220,12 @@ impl ServerMessageResponse {
     }
 
     #[must_use]
+    pub fn push_nameplate(mut self, cmd: ClientNameplateDrawCmd) -> Self {
+        self.output.presentation.nameplates.push(cmd);
+        self
+    }
+
+    #[must_use]
     pub fn finish(self) -> ServerMessageResult {
         ServerMessageResult {
             output: self.output,
@@ -848,6 +1258,12 @@ impl LifecycleResponse {
             block_id,
             expected_old: None,
         });
+        self
+    }
+
+    #[must_use]
+    pub fn push_nameplate(mut self, cmd: ClientNameplateDrawCmd) -> Self {
+        self.output.presentation.nameplates.push(cmd);
         self
     }
 
@@ -996,6 +1412,29 @@ pub mod __private {
             .expect("guest encoding must succeed")
     }
 
+    fn module_worldgen_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
+        let input = decode_required_input::<WorldGenCallInput>(input);
+        postcard::to_allocvec(&module.handle_worldgen(input)).expect("guest encoding must succeed")
+    }
+
+    fn module_character_controller_init_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
+        let input = decode_required_input::<CharacterControllerInitInput>(input);
+        postcard::to_allocvec(&module.handle_character_controller_init(input))
+            .expect("guest encoding must succeed")
+    }
+
+    fn module_character_controller_step_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
+        let input = decode_required_input::<CharacterControllerStepInput>(input);
+        postcard::to_allocvec(&module.handle_character_controller_step(input))
+            .expect("guest encoding must succeed")
+    }
+
+    fn module_client_control_provider_bytes(module: &GuestModule, input: &[u8]) -> Vec<u8> {
+        let input = decode_required_input::<ClientControlSampleInput>(input);
+        postcard::to_allocvec(&module.handle_client_control_provider(input))
+            .expect("guest encoding must succeed")
+    }
+
     pub fn wasm_guest_alloc(size: u32) -> u32 {
         let mut buf = Vec::<u8>::with_capacity(size as usize);
         let ptr = buf.as_mut_ptr();
@@ -1061,6 +1500,30 @@ pub mod __private {
     pub fn wasm_guest_server_messages(module: &GuestModule, ptr: u32, len: u32) -> u64 {
         with_wasm_input_bytes(ptr, len, |input| {
             encode_to_wasm_guest(&module_server_messages_bytes(module, input))
+        })
+    }
+
+    pub fn wasm_guest_worldgen(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_worldgen_bytes(module, input))
+        })
+    }
+
+    pub fn wasm_guest_character_controller_init(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_character_controller_init_bytes(module, input))
+        })
+    }
+
+    pub fn wasm_guest_character_controller_step(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_character_controller_step_bytes(module, input))
+        })
+    }
+
+    pub fn wasm_guest_client_control_provider(module: &GuestModule, ptr: u32, len: u32) -> u64 {
+        with_wasm_input_bytes(ptr, len, |input| {
+            encode_to_wasm_guest(&module_client_control_provider_bytes(module, input))
         })
     }
 
@@ -1168,6 +1631,42 @@ pub mod __private {
         })
     }
 
+    pub fn native_guest_worldgen(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_worldgen_bytes(module, input))
+        })
+    }
+
+    pub fn native_guest_character_controller_init(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_character_controller_init_bytes(module, input))
+        })
+    }
+
+    pub fn native_guest_character_controller_step(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_character_controller_step_bytes(module, input))
+        })
+    }
+
+    pub fn native_guest_client_control_provider(
+        module: &GuestModule,
+        input: NativeGuestInput,
+    ) -> NativeGuestBuffer {
+        with_native_input_bytes(input, |input| {
+            encode_to_native_guest(module_client_control_provider_bytes(module, input))
+        })
+    }
+
     fn decode_default_input<T>(bytes: &[u8]) -> T
     where
         T: Default + serde::de::DeserializeOwned,
@@ -1231,6 +1730,7 @@ pub mod __private {
         lifecycle: LifecycleHooks,
         action: bool,
         messages: MessageHooks,
+        providers: ProviderHooks,
     ) {
         let callbacks = module.description().callbacks;
         assert_eq!(
@@ -1245,6 +1745,10 @@ pub mod __private {
             callbacks.messages, messages,
             "freven_guest_sdk message export surface does not match GuestModule::description()",
         );
+        assert_eq!(
+            callbacks.providers, providers,
+            "freven_guest_sdk provider export surface does not match GuestModule::description()",
+        );
     }
 }
 
@@ -1256,6 +1760,9 @@ macro_rules! export_wasm_guest {
         $(, actions: $actions:tt)?
         $(, client_messages: $client_messages:tt)?
         $(, server_messages: $server_messages:tt)?
+        $(, worldgen: $worldgen:tt)?
+        $(, character_controller: $character_controller:tt)?
+        $(, client_control_provider: $client_control_provider:tt)?
         $(,)?
     ) => {
         #[unsafe(no_mangle)]
@@ -1279,6 +1786,11 @@ macro_rules! export_wasm_guest {
                     client: $crate::export_wasm_guest!(@bool $($client_messages)?),
                     server: $crate::export_wasm_guest!(@bool $($server_messages)?),
                 },
+                $crate::ProviderHooks {
+                    worldgen: $crate::export_wasm_guest!(@bool $($worldgen)?),
+                    character_controller: $crate::export_wasm_guest!(@bool $($character_controller)?),
+                    client_control_provider: $crate::export_wasm_guest!(@bool $($client_control_provider)?),
+                },
             );
             $crate::__private::wasm_guest_negotiate(&module, ptr, len)
         }
@@ -1290,6 +1802,17 @@ macro_rules! export_wasm_guest {
         $crate::export_wasm_guest!(@maybe_export_action $factory, $($actions)?);
         $crate::export_wasm_guest!(@maybe_export_client_messages $factory, $($client_messages)?);
         $crate::export_wasm_guest!(@maybe_export_server_messages $factory, $($server_messages)?);
+        $crate::export_wasm_guest!(@maybe_export_worldgen $factory, $($worldgen)?);
+        $crate::export_wasm_guest!(
+            @maybe_export_character_controller
+            $factory,
+            $($character_controller)?
+        );
+        $crate::export_wasm_guest!(
+            @maybe_export_client_control_provider
+            $factory,
+            $($client_control_provider)?
+        );
     };
 
     (@lifecycle_struct $($hook:ident),*) => {{
@@ -1384,6 +1907,45 @@ macro_rules! export_wasm_guest {
     (@maybe_export_server_messages $factory:path,) => {};
     (@maybe_export_server_messages $factory:path, false) => {};
     (@maybe_export_server_messages $factory:path) => {};
+
+    (@maybe_export_worldgen $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_generate_worldgen(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::wasm_guest_worldgen(&module, ptr, len)
+        }
+    };
+    (@maybe_export_worldgen $factory:path, false) => {};
+    (@maybe_export_worldgen $factory:path,) => {};
+    (@maybe_export_worldgen $factory:path) => {};
+
+    (@maybe_export_character_controller $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_init_character_controller(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::wasm_guest_character_controller_init(&module, ptr, len)
+        }
+
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_step_character_controller(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::wasm_guest_character_controller_step(&module, ptr, len)
+        }
+    };
+    (@maybe_export_character_controller $factory:path, false) => {};
+    (@maybe_export_character_controller $factory:path,) => {};
+    (@maybe_export_character_controller $factory:path) => {};
+
+    (@maybe_export_client_control_provider $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_sample_client_control_provider(ptr: u32, len: u32) -> u64 {
+            let module = $factory();
+            $crate::__private::wasm_guest_client_control_provider(&module, ptr, len)
+        }
+    };
+    (@maybe_export_client_control_provider $factory:path, false) => {};
+    (@maybe_export_client_control_provider $factory:path,) => {};
+    (@maybe_export_client_control_provider $factory:path) => {};
 }
 
 #[macro_export]
@@ -1394,6 +1956,9 @@ macro_rules! export_native_guest {
         $(, actions: $actions:tt)?
         $(, client_messages: $client_messages:tt)?
         $(, server_messages: $server_messages:tt)?
+        $(, worldgen: $worldgen:tt)?
+        $(, character_controller: $character_controller:tt)?
+        $(, client_control_provider: $client_control_provider:tt)?
         $(,)?
     ) => {
         #[unsafe(no_mangle)]
@@ -1426,6 +1991,11 @@ macro_rules! export_native_guest {
                     client: $crate::export_native_guest!(@bool $($client_messages)?),
                     server: $crate::export_native_guest!(@bool $($server_messages)?),
                 },
+                $crate::ProviderHooks {
+                    worldgen: $crate::export_native_guest!(@bool $($worldgen)?),
+                    character_controller: $crate::export_native_guest!(@bool $($character_controller)?),
+                    client_control_provider: $crate::export_native_guest!(@bool $($client_control_provider)?),
+                },
             );
             $crate::__private::native_guest_negotiate(&module, input)
         }
@@ -1437,6 +2007,17 @@ macro_rules! export_native_guest {
         $crate::export_native_guest!(@maybe_export_action $factory, $($actions)?);
         $crate::export_native_guest!(@maybe_export_client_messages $factory, $($client_messages)?);
         $crate::export_native_guest!(@maybe_export_server_messages $factory, $($server_messages)?);
+        $crate::export_native_guest!(@maybe_export_worldgen $factory, $($worldgen)?);
+        $crate::export_native_guest!(
+            @maybe_export_character_controller
+            $factory,
+            $($character_controller)?
+        );
+        $crate::export_native_guest!(
+            @maybe_export_client_control_provider
+            $factory,
+            $($client_control_provider)?
+        );
     };
 
     (@lifecycle_struct $($hook:ident),*) => {{
@@ -1545,6 +2126,53 @@ macro_rules! export_native_guest {
     (@maybe_export_server_messages $factory:path,) => {};
     (@maybe_export_server_messages $factory:path, false) => {};
     (@maybe_export_server_messages $factory:path) => {};
+
+    (@maybe_export_worldgen $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_generate_worldgen(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::native_guest_worldgen(&module, input)
+        }
+    };
+    (@maybe_export_worldgen $factory:path, false) => {};
+    (@maybe_export_worldgen $factory:path,) => {};
+    (@maybe_export_worldgen $factory:path) => {};
+
+    (@maybe_export_character_controller $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_init_character_controller(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::native_guest_character_controller_init(&module, input)
+        }
+
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_step_character_controller(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::native_guest_character_controller_step(&module, input)
+        }
+    };
+    (@maybe_export_character_controller $factory:path, false) => {};
+    (@maybe_export_character_controller $factory:path,) => {};
+    (@maybe_export_character_controller $factory:path) => {};
+
+    (@maybe_export_client_control_provider $factory:path, true) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn freven_guest_sample_client_control_provider(
+            input: $crate::NativeGuestInput,
+        ) -> $crate::NativeGuestBuffer {
+            let module = $factory();
+            $crate::__private::native_guest_client_control_provider(&module, input)
+        }
+    };
+    (@maybe_export_client_control_provider $factory:path, false) => {};
+    (@maybe_export_client_control_provider $factory:path,) => {};
+    (@maybe_export_client_control_provider $factory:path) => {};
 }
 
 #[macro_export]
@@ -1980,6 +2608,7 @@ mod tests {
                 client: false,
                 server: true,
             },
+            ProviderHooks::default(),
         );
     }
 
@@ -1994,6 +2623,7 @@ mod tests {
                 client: false,
                 server: true,
             },
+            ProviderHooks::default(),
         );
     }
 
@@ -2012,6 +2642,7 @@ mod tests {
                 client: false,
                 server: true,
             },
+            ProviderHooks::default(),
         );
     }
 
@@ -2030,6 +2661,7 @@ mod tests {
                 client: false,
                 server: false,
             },
+            ProviderHooks::default(),
         );
     }
 

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -83,9 +83,11 @@ Current hosting policy:
 
 - compile-time/builtin registration hosts all currently implemented declaration
   families
-- runtime-loaded guest transports may declare provider families canonically, but
-  host policy currently rejects them explicitly because guest factory/runtime
-  hosting for those families does not exist yet
+- Wasm and native guest transports host provider families
+  (`worldgen`, `character_controllers`, `client_control_providers`) through the
+  same canonical registration model used by builtin mods
+- external-process guest execution still policy-gates provider families
+  explicitly because that transport does not yet expose safe provider hosting
 - this is an execution/policy gate, not a separate public declaration model
 
 ## Action path

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -34,6 +34,13 @@ A native mod dynamic library must export these symbols:
   when `callbacks.lifecycle.tick_client = true`
 - `freven_guest_on_tick_server(input: NativeGuestInput) -> NativeGuestBuffer`
   when `callbacks.lifecycle.tick_server = true`
+- `freven_guest_generate_worldgen(input: NativeGuestInput) -> NativeGuestBuffer`
+  when `callbacks.providers.worldgen = true`
+- `freven_guest_init_character_controller(input: NativeGuestInput) -> NativeGuestBuffer`
+  and `freven_guest_step_character_controller(input: NativeGuestInput) -> NativeGuestBuffer`
+  when `callbacks.providers.character_controller = true`
+- `freven_guest_sample_client_control_provider(input: NativeGuestInput) -> NativeGuestBuffer`
+  when `callbacks.providers.client_control_provider = true`
 
 FFI structs:
 
@@ -104,9 +111,9 @@ Runtime validates and enforces:
 - message routing uses the negotiated registration contract:
   inbound delivery only for declared side-appropriate readable channels, outbound sends only for declared side-appropriate writable channels and declared message ids
 - provider-family declarations (`worldgen`, `character_controllers`,
-  `client_control_providers`) are part of the canonical guest model, but native
-  guest execution still rejects them explicitly because guest-side provider
-  hosting is not implemented yet
+  `client_control_providers`) are hosted for native guest execution when the
+  active side supports them; unsupported execution/policy classes are rejected
+  explicitly instead of falling back to builtin-only semantics
 
 On decode/validation/contract errors, attach fails.
 On lifecycle, action-call, or message contract faults, runtime disables that

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -41,6 +41,13 @@ Optional lifecycle exports:
 - `freven_guest_on_start_server(ptr: u32, len: u32) -> u64`
 - `freven_guest_on_tick_client(ptr: u32, len: u32) -> u64`
 - `freven_guest_on_tick_server(ptr: u32, len: u32) -> u64`
+- `freven_guest_generate_worldgen(ptr: u32, len: u32) -> u64`
+  when `callbacks.providers.worldgen = true`
+- `freven_guest_init_character_controller(ptr: u32, len: u32) -> u64` and
+  `freven_guest_step_character_controller(ptr: u32, len: u32) -> u64`
+  when `callbacks.providers.character_controller = true`
+- `freven_guest_sample_client_control_provider(ptr: u32, len: u32) -> u64`
+  when `callbacks.providers.client_control_provider = true`
 
 `freven_guest_negotiate`, lifecycle callbacks, and `freven_guest_handle_action`
 return packed `(ptr, len)` as:
@@ -73,8 +80,8 @@ Host behavior:
 - validates `selected_contract_version`
 - validates `GuestDescription.callbacks` against exported Wasm symbols
 - registers `GuestDescription.registration` into the canonical host runtime
-- rejects canonically declared provider families when host execution/policy does
-  not support guest-side provider hosting yet
+- hosts canonically declared provider families when the current side and policy
+  support them, and rejects them explicitly otherwise
 - maps runtime action kind to `registration.actions[].binding_id` for callback dispatch
 
 ### Lifecycle inputs and outputs


### PR DESCRIPTION
## Summary
This PR broadens the public guest contract in `freven-sdk` to cover hosted provider families and the next layer of runtime services.

It adds canonical provider callback hooks, provider call payloads, presentation outputs, and the runtime request/response surface needed for client presentation, client control, and character physics. It also updates the SDK facade so provider factories use shared `Arc` closures instead of plain function pointers.

## What changed
- added canonical provider callback hooks to the public guest model
- added guest payload/result types for:
  - worldgen
  - character controller init/step
  - client control provider sampling
- added presentation output types, including client nameplate draw commands
- added runtime read/service requests and responses for:
  - client player views
  - world-to-screen lookups
  - client control access
  - character physics access
- updated `freven_api` to re-export the expanded public contract
- changed provider factories in `freven_api` to `Arc`-backed closures
- extended `freven_guest_sdk` builders, handlers, runtime helpers, and export macros for provider families
- refreshed guest contract and ABI docs to describe hosted provider families instead of treating them as compile-time-only semantics

## Why
The SDK now needs to describe the same canonical contract that hosted runtimes execute.

This PR makes the public model honest and complete by:
- giving provider families first-class runtime semantics
- exposing the runtime services needed by guest-side controllers and control providers
- allowing presentation outputs to flow through the canonical contract
- aligning SDK helpers and exported surfaces with the runtime host model

## Notes
Wasm and native guests are now modeled as real hosts for provider families in the public contract. Execution classes that still cannot host a family safely remain explicitly policy-gated rather than relying on separate builtin-only semantics.