### PR TITLE
Document canonical provider hosting across builtin and guest transports

### DIFF
--- a/crates/freven_guest_sdk/README.md
+++ b/crates/freven_guest_sdk/README.md
@@ -82,10 +82,9 @@ intentionally need to wire the raw surface yourself.
 - Capability declarations are validated honestly by the runtime:
   empty keys fail, and unknown capability keys are rejected against host policy.
 - Provider families use the same canonical declaration model as builtin mods.
-  Wasm and native guests can now host `worldgen`, `character_controllers`, and
-  `client_control_providers`; transports that cannot support a family for a
-  given execution/policy class must still declare it canonically and are gated
-  explicitly by host policy.
+  Wasm, native, and external guests now host `worldgen`,
+  `character_controllers`, and `client_control_providers` through one runtime
+  model; side-specific hosting still follows the canonical runtime side rules.
 - Stateful guest authoring now has an explicit session model through
   `StatefulGuestModule` / `stateful_wasm_guest!`: the SDK owns a per-runtime-session
   state slot, reuses it across callbacks in that session, and rotates it when a

--- a/docs/EXTERNAL_MOD_IPC_v1.md
+++ b/docs/EXTERNAL_MOD_IPC_v1.md
@@ -39,6 +39,18 @@ process boundary.
   - payload: `input: TickInput`
 - `handle_action`
   - payload: `input: ActionInput`
+- `client_messages`
+  - payload: `input: ClientMessageInput`
+- `server_messages`
+  - payload: `input: ServerMessageInput`
+- `generate_worldgen`
+  - payload: `input: WorldGenCallInput`
+- `init_character_controller`
+  - payload: `input: CharacterControllerInitInput`
+- `step_character_controller`
+  - payload: `input: CharacterControllerStepInput`
+- `sample_client_control_provider`
+  - payload: `input: ClientControlSampleInput`
 - `shutdown`
   - best-effort clean shutdown request sent by host before process kill fallback
 
@@ -58,6 +70,14 @@ process boundary.
   - payload: `result: ClientMessageResult`
 - `server_messages`
   - payload: `result: ServerMessageResult`
+- `generate_worldgen`
+  - payload: `result: WorldGenCallResult`
+- `init_character_controller`
+  - payload: `result: CharacterControllerInitResult`
+- `step_character_controller`
+  - payload: `result: CharacterControllerStepResult`
+- `sample_client_control_provider`
+  - payload: `result: ClientControlSampleResult`
 - `error`
   - payload: `message: String`
 
@@ -72,18 +92,33 @@ per-mod config document (`ModConfigDocument`, currently TOML text).
   `guest_id` that matches the resolved mod id.
 - Negotiated lifecycle declarations may include both client and server hooks.
   The runtime hosts the active side as a subset for the current session.
-- External transport supports the full `freven_guest` surface; if the guest
-  declares a lifecycle hook, the companion process must answer the
+- External transport supports the full `freven_guest` callback surface:
+  lifecycle, action, message, and provider families all use the same canonical
+  declaration model as builtin/Wasm/native guests.
+- Side-specific hosting matches the canonical runtime model:
+  `generate_worldgen` is issued only on server runtime sessions,
+  `sample_client_control_provider` only on client runtime sessions,
+  `init_character_controller` / `step_character_controller` on either side when
+  that provider family is hosted there.
+- If the guest declares a lifecycle hook, the companion process must answer the
   corresponding request with a `lifecycle` response carrying `LifecycleResult`.
+- If the guest declares a provider callback family, the companion process must
+  answer the corresponding provider request with the matching provider result
+  envelope. Declared provider families must not be left operationally dead.
 - A guest callback may emit one or more `service_request` envelopes before it
   emits its terminal `lifecycle` / `handle_action` / `client_messages` /
-  `server_messages` response.
+  `server_messages` / provider response.
 - The host answers each `service_request` with a matching `service_response`
   using the same envelope `id`, then continues waiting for the terminal
   callback response.
+- Provider callbacks share the same runtime session lifetime as lifecycle,
+  action, and message callbacks. A provider timeout, decode failure, protocol
+  violation, invalid result, or runtime-service misuse disables that guest for
+  the current runtime session and later callbacks/actions are rejected.
 - If a companion process exits/crashes, disconnects, violates protocol, or times out:
   - that mod is disabled for the current runtime session
   - later lifecycle callbacks stop
+  - later provider callbacks fault/reject through the disabled session
   - action calls for that mod return `ActionOutcome::Rejected`
   - host kills/waits child if still alive
 - If a valid `ActionResult` cannot be completed because host-side runtime-command

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -74,7 +74,7 @@ Registration/callback invariants:
 - `callbacks.action = true` requires at least one declared action
 - provider families (`worldgen`, `character_controllers`,
   `client_control_providers`) are part of the canonical public declaration
-  model even when a given execution/policy class does not host them yet
+  model across builtin, Wasm, native, and external guests
 - capability keys must be non-empty
 - declared capability keys must exist in the resolved host capability table
 
@@ -82,12 +82,16 @@ Current hosting policy:
 
 - compile-time/builtin registration hosts all currently implemented declaration
   families
-- Wasm and native guest transports host provider families
+- Wasm, native, and external guest transports host provider families
   (`worldgen`, `character_controllers`, `client_control_providers`) through the
   same canonical registration model used by builtin mods
-- external-process guest execution still policy-gates provider families
-  explicitly because that transport does not yet expose safe provider hosting
-- this is an execution/policy gate, not a separate public declaration model
+- side-specific hosting is explicit:
+  `worldgen` is hosted on server runtime sessions,
+  `client_control_providers` are hosted on client runtime sessions,
+  `character_controllers` are hosted on both sides
+- external-process execution may still be blocked by explicit trust/policy
+  settings such as `allow_external_mods`, but provider families are no longer a
+  separate external-only semantic exception
 
 ## Action path
 

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -115,8 +115,8 @@ Runtime validates and enforces:
   inbound delivery only for declared side-appropriate readable channels, outbound sends only for declared side-appropriate writable channels and declared message ids
 - provider-family declarations (`worldgen`, `character_controllers`,
   `client_control_providers`) are hosted for native guest execution when the
-  active side supports them; unsupported execution/policy classes are rejected
-  explicitly instead of falling back to builtin-only semantics
+  active side supports them; this matches the same canonical provider model
+  used by builtin, Wasm, and external guests
 
 On decode/validation/contract errors, attach fails.
 On lifecycle, action-call, or message contract faults, runtime disables that

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -49,6 +49,10 @@ Optional lifecycle exports:
 - `freven_guest_sample_client_control_provider(ptr: u32, len: u32) -> u64`
   when `callbacks.providers.client_control_provider = true`
 
+These provider exports participate in the same canonical provider-family model
+used by builtin, native, and external guest transports; side-specific hosting
+is decided by the runtime session, not by a separate Wasm-only semantic rule.
+
 `freven_guest_negotiate`, lifecycle callbacks, and `freven_guest_handle_action`
 return packed `(ptr, len)` as:
 


### PR DESCRIPTION
## Summary
This PR updates the SDK and contract docs to match the runtime model now implemented in the engine.

It documents that builtin, wasm, native, and external guests all participate in the same canonical provider-family model, with side-specific hosting rules and session-wide fault semantics.

## What changed
- updated `freven_guest_sdk` docs to say that external guests now host provider families too
- updated the guest contract docs to remove the old external-provider exception
- clarified that provider families share one canonical model across:
  - builtin mods
  - wasm guests
  - native guests
  - external guests
- documented the side-specific hosting rules for:
  - `worldgen`
  - `character_controllers`
  - `client_control_providers`
- expanded the external IPC docs with provider callback request/response envelopes
- documented that provider callbacks share the same runtime-session fault semantics as lifecycle, action, and message callbacks
- aligned wasm/native ABI docs with the canonical cross-transport provider model

## Why
The public documentation should describe the real runtime contract.

This PR keeps the SDK/docs honest by removing the old idea that external guests are a separate provider-model exception and replacing it with the actual canonical rule: one provider-family model, side-specific hosting, and disable-for-session fault handling across transports.