### PR TITLE
Define canonical observability and logging contracts

### DIFF
--- a/crates/freven_api/src/lib.rs
+++ b/crates/freven_api/src/lib.rs
@@ -11,7 +11,7 @@
 //! - keep hook/context types engine-agnostic
 //! - avoid leaking runtime/transport implementation details
 
-use std::{sync::Arc, time::Duration};
+use std::{cell::RefCell, ffi::c_void, sync::Arc, time::Duration};
 
 use serde::de::DeserializeOwned;
 
@@ -19,13 +19,13 @@ pub use freven_guest::{
     CharacterControllerDeclaration, ClientControlProviderDeclaration,
     ClientNameplateDrawCmd as GuestClientNameplateDrawCmd,
     ClientPlayerView as GuestClientPlayerView, GuestCallbacks as ModCallbackModel,
-    GuestRegistration as ModDeclarationModel, LifecycleHooks as LifecycleCallbackModel,
-    MessageHooks as MessageCallbackModel, ModConfigDocument as GuestModConfigDocument,
+    GuestRegistration as ModDeclarationModel, LifecycleHooks as LifecycleCallbackModel, LogLevel,
+    LogPayload, MessageHooks as MessageCallbackModel, ModConfigDocument as GuestModConfigDocument,
     ModConfigFormat as GuestModConfigFormat, ProviderHooks as ProviderCallbackModel,
     RuntimeCharacterPhysicsRequest, RuntimeClientControlRequest, RuntimeCommandOutput,
-    RuntimeEntityTarget, RuntimeLevelRef, RuntimeOutput, RuntimePresentationOutput,
-    RuntimeReadRequest, RuntimeServiceRequest, RuntimeServiceResponse, RuntimeSideRequest,
-    WorldCommand, WorldGenDeclaration,
+    RuntimeEntityTarget, RuntimeLevelRef, RuntimeObservabilityRequest, RuntimeOutput,
+    RuntimePresentationOutput, RuntimeReadRequest, RuntimeServiceRequest, RuntimeServiceResponse,
+    RuntimeSessionInfo, RuntimeSessionSide, RuntimeSideRequest, WorldCommand, WorldGenDeclaration,
 };
 pub use freven_sdk_types::blocks::{BlockDef, BlockRuntimeId, RenderLayer};
 pub use freven_sdk_types::{blocks, voxel};
@@ -34,6 +34,86 @@ pub use freven_sdk_types::{blocks, voxel};
 pub mod engine_components {
     /// Optional per-player display name payload (UTF-8 bytes).
     pub const PLAYER_NAMEPLATE_TEXT: &str = "freven.engine:player_nameplate_text";
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostExecutionKind {
+    Builtin,
+    Wasm,
+    Native,
+    External,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogCallbackFamily {
+    StartClient,
+    StartServer,
+    TickClient,
+    TickServer,
+    ClientMessages,
+    ServerMessages,
+    Action,
+    Worldgen,
+    CharacterControllerInit,
+    CharacterControllerStep,
+    ClientControlSample,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostLogContext {
+    pub mod_id: String,
+    pub execution: HostExecutionKind,
+    pub side: RuntimeSessionSide,
+    pub runtime_session_id: u64,
+    pub source: Option<String>,
+    pub artifact: Option<String>,
+    pub trust: Option<String>,
+    pub policy: Option<String>,
+    pub callback: Option<LogCallbackFamily>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostLogRecord {
+    pub payload: LogPayload,
+    pub context: HostLogContext,
+}
+
+pub type ObservabilityEmitFn =
+    unsafe fn(ctx: *mut c_void, level: LogLevel, message_ptr: *const u8, message_len: usize);
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ObservabilityBridge {
+    pub ctx: *mut c_void,
+    pub emit: Option<ObservabilityEmitFn>,
+}
+
+impl ObservabilityBridge {
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            ctx: core::ptr::null_mut(),
+            emit: None,
+        }
+    }
+}
+
+thread_local! {
+    static OBSERVABILITY_BRIDGE: RefCell<ObservabilityBridge> =
+        const { RefCell::new(ObservabilityBridge::empty()) };
+}
+
+pub fn emit_log(level: LogLevel, message: impl AsRef<str>) {
+    let message = message.as_ref();
+    OBSERVABILITY_BRIDGE.with(|slot| {
+        let bridge = *slot.borrow();
+        let Some(emit) = bridge.emit else {
+            return;
+        };
+        unsafe {
+            emit(bridge.ctx, level, message.as_ptr(), message.len());
+        }
+    });
 }
 
 /// Stable id for a logical player action kind.
@@ -120,6 +200,11 @@ impl<'a> ActionContext<'a> {
             player_id,
             at_input_seq,
         }
+    }
+
+    pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
+        let _ = &self.services;
+        emit_log(level, message);
     }
 }
 
@@ -571,6 +656,8 @@ pub trait Services {
             })
         }
     }
+
+    fn record_guest_log(&mut self, _record: &HostLogRecord) {}
 }
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
@@ -957,6 +1044,11 @@ impl<'a> ServerApi<'a> {
     pub fn new(services: &'a mut dyn Services) -> Self {
         Self { services }
     }
+
+    pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
+        let _ = &self.services;
+        emit_log(level, message);
+    }
 }
 
 /// Client-side lifecycle API.
@@ -1000,6 +1092,11 @@ impl<'a> ClientApi<'a> {
             nameplates: self.nameplates,
         }
     }
+
+    pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
+        let _ = &self.services;
+        emit_log(level, message);
+    }
 }
 
 /// Client-side message dispatch context.
@@ -1028,6 +1125,11 @@ impl<'a> ClientMessagesApi<'a> {
             sender,
         }
     }
+
+    pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
+        let _ = &self.services;
+        emit_log(level, message);
+    }
 }
 
 /// Server-side message dispatch context.
@@ -1055,6 +1157,11 @@ impl<'a> ServerMessagesApi<'a> {
             inbound,
             sender,
         }
+    }
+
+    pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
+        let _ = &self.services;
+        emit_log(level, message);
     }
 }
 
@@ -1116,6 +1223,10 @@ impl<'a> ClientTickApi<'a> {
     pub fn new(tick: u64, dt: Duration, client: ClientApi<'a>) -> Self {
         Self { tick, dt, client }
     }
+
+    pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
+        self.client.log(level, message);
+    }
 }
 
 /// Server-side lifecycle tick context.
@@ -1129,6 +1240,10 @@ impl<'a> ServerTickApi<'a> {
     #[must_use]
     pub fn new(tick: u64, dt: Duration, server: ServerApi<'a>) -> Self {
         Self { tick, dt, server }
+    }
+
+    pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
+        self.server.log(level, message);
     }
 }
 
@@ -1468,4 +1583,21 @@ pub struct ChannelConfig {
     pub ordering: ChannelOrdering,
     pub direction: ChannelDirection,
     pub budget: Option<ChannelBudget>,
+}
+
+#[doc(hidden)]
+pub mod __private {
+    use super::{OBSERVABILITY_BRIDGE, ObservabilityBridge};
+
+    pub fn with_observability_bridge<T>(
+        bridge: ObservabilityBridge,
+        call: impl FnOnce() -> T,
+    ) -> T {
+        OBSERVABILITY_BRIDGE.with(|slot| {
+            let previous = slot.replace(bridge);
+            let result = call();
+            slot.replace(previous);
+            result
+        })
+    }
 }

--- a/crates/freven_guest/src/lib.rs
+++ b/crates/freven_guest/src/lib.rs
@@ -8,6 +8,7 @@ extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
 use freven_sdk_types::blocks::BlockDef;
+pub use freven_sdk_types::observability::{LogLevel, LogPayload};
 use serde::{Deserialize, Serialize};
 
 pub const GUEST_CONTRACT_VERSION_1: u32 = 1;
@@ -658,12 +659,18 @@ pub enum RuntimeCharacterPhysicsRequest {
     },
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RuntimeObservabilityRequest {
+    Log(LogPayload),
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum RuntimeServiceRequest {
     Read(RuntimeReadRequest),
     Side(RuntimeSideRequest),
     ClientControl(RuntimeClientControlRequest),
     CharacterPhysics(RuntimeCharacterPhysicsRequest),
+    Observability(RuntimeObservabilityRequest),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -684,5 +691,6 @@ pub enum RuntimeServiceResponse {
     CharacterPhysicsIsSolidWorldCollision(bool),
     CharacterPhysicsSweepAabb(SweepHit),
     CharacterPhysicsMoveAabbTerrain(KinematicMoveResult),
+    Acknowledged,
     Unsupported,
 }

--- a/crates/freven_guest_sdk/src/lib.rs
+++ b/crates/freven_guest_sdk/src/lib.rs
@@ -18,16 +18,16 @@ pub use freven_guest::{
     ClientMessageResult, ClientMouseButton, ClientNameplateDrawCmd, ClientOutboundMessage,
     ClientOutboundMessageScope, ClientPlayerView, ComponentCodec, ComponentDeclaration,
     GUEST_CONTRACT_VERSION_1, GuestCallbacks, GuestDescription, GuestRegistration, InputTimeline,
-    KinematicMoveConfig, KinematicMoveResult, LifecycleHooks, LifecycleResult, MessageCodec,
-    MessageDeclaration, MessageHooks, MessageScope, ModConfigDocument, ModConfigFormat,
-    NegotiationRequest, NegotiationResponse, ProviderHooks, RuntimeCharacterPhysicsRequest,
-    RuntimeClientControlRequest, RuntimeCommandOutput, RuntimeEntityTarget, RuntimeLevelRef,
-    RuntimeMessageOutput, RuntimeOutput, RuntimePresentationOutput, RuntimeReadRequest,
-    RuntimeServiceRequest, RuntimeServiceResponse, RuntimeSessionInfo, RuntimeSessionSide,
-    RuntimeSideRequest, ServerInboundMessage, ServerMessageInput, ServerMessageResult,
-    ServerOutboundMessage, StartInput, SweepHit, TickInput, WorldCommand, WorldGenCallInput,
-    WorldGenCallResult, WorldGenDeclaration, WorldGenInit, WorldGenOutput, WorldGenRequest,
-    WorldGenSection,
+    KinematicMoveConfig, KinematicMoveResult, LifecycleHooks, LifecycleResult, LogLevel,
+    LogPayload, MessageCodec, MessageDeclaration, MessageHooks, MessageScope, ModConfigDocument,
+    ModConfigFormat, NegotiationRequest, NegotiationResponse, ProviderHooks,
+    RuntimeCharacterPhysicsRequest, RuntimeClientControlRequest, RuntimeCommandOutput,
+    RuntimeEntityTarget, RuntimeLevelRef, RuntimeMessageOutput, RuntimeObservabilityRequest,
+    RuntimeOutput, RuntimePresentationOutput, RuntimeReadRequest, RuntimeServiceRequest,
+    RuntimeServiceResponse, RuntimeSessionInfo, RuntimeSessionSide, RuntimeSideRequest,
+    ServerInboundMessage, ServerMessageInput, ServerMessageResult, ServerOutboundMessage,
+    StartInput, SweepHit, TickInput, WorldCommand, WorldGenCallInput, WorldGenCallResult,
+    WorldGenDeclaration, WorldGenInit, WorldGenOutput, WorldGenRequest, WorldGenSection,
 };
 pub use freven_sdk_types::blocks::{BlockDef, RenderLayer};
 use serde::de::DeserializeOwned;
@@ -1302,6 +1302,15 @@ impl StartInputExt for StartInput {
 pub struct RuntimeServices;
 
 impl RuntimeServices {
+    pub fn log(self, level: LogLevel, message: impl Into<String>) {
+        let _ = runtime_service_call(RuntimeServiceRequest::Observability(
+            RuntimeObservabilityRequest::Log(LogPayload {
+                level,
+                message: message.into(),
+            }),
+        ));
+    }
+
     #[must_use]
     pub fn block_world(self, pos: (i32, i32, i32)) -> Option<u8> {
         match runtime_service_call(RuntimeServiceRequest::Read(

--- a/crates/freven_sdk_types/src/lib.rs
+++ b/crates/freven_sdk_types/src/lib.rs
@@ -1,4 +1,5 @@
 //! Shared pure SDK data contracts.
 
 pub mod blocks;
+pub mod observability;
 pub mod voxel;

--- a/crates/freven_sdk_types/src/observability.rs
+++ b/crates/freven_sdk_types/src/observability.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LogPayload {
+    pub level: LogLevel,
+    pub message: String,
+}

--- a/docs/EXTERNAL_MOD_IPC_v1.md
+++ b/docs/EXTERNAL_MOD_IPC_v1.md
@@ -111,6 +111,8 @@ per-mod config document (`ModConfigDocument`, currently TOML text).
 - The host answers each `service_request` with a matching `service_response`
   using the same envelope `id`, then continues waiting for the terminal
   callback response.
+- Logging for external guests is not `stderr`-based. It uses the same explicit
+  `service_request` path as other canonical runtime services.
 - Provider callbacks share the same runtime session lifetime as lifecycle,
   action, and message callbacks. A provider timeout, decode failure, protocol
   violation, invalid result, or runtime-service misuse disables that guest for
@@ -127,3 +129,37 @@ per-mod config document (`ModConfigDocument`, currently TOML text).
   - follow-up lifecycle/action calls are rejected
   - host kills/waits the companion child
 - External mods are loaded only when explicit policy is enabled (for example `--allow-external-mods` or `FREVEN_ALLOW_EXTERNAL_MODS=1`).
+
+## Observability / logging
+
+External guests emit logs through the canonical service channel:
+
+- response envelope: `service_request`
+- request payload: `RuntimeServiceRequest::Observability(RuntimeObservabilityRequest::Log(LogPayload))`
+- canonical payload: `LogPayload { level, message }`
+- levels: `debug`, `info`, `warn`, `error`
+
+The process boundary does not create separate logging semantics. External mods
+still provide only level and message text. The host/runtime owns attribution,
+policy, filtering, sanitization, truncation, rate limiting, routing, and final
+presentation.
+
+Every accepted external log is enriched host-side where available with mod
+identity, execution kind (`external`), side, runtime session id, source,
+artifact, trust, policy, and active callback family.
+
+Session enforcement is mandatory:
+
+- log ingestion is valid only while the active runtime session is alive
+- after disable-for-session, detach, restart, unload, hot reload, world reload,
+  or reattach, later logs from the old binding must be ignored/rejected
+- host teardown must close the effective ingestion path so the old process
+  cannot keep producing semantically live logs after session end
+
+Fault policy distinguishes policy outcomes from boundary violations:
+
+- oversized messages may be truncated safely
+- spam may be dropped or summarized by host policy
+- debug logs may be hidden by host policy
+- malformed JSON/envelopes, impossible logging payloads, or protocol misuse are
+  contract violations that disable the guest for the current runtime session

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -146,6 +146,7 @@ Guest/runtime-loaded mods now use explicit runtime service families:
 
 - `RuntimeServiceRequest::Read(...)`
 - `RuntimeServiceRequest::Side(...)`
+- `RuntimeServiceRequest::Observability(...)`
 - `RuntimeOutput.messages`
 - `RuntimeOutput.commands`
 
@@ -163,6 +164,37 @@ Current side-specific requests include:
 - client next input sequence
 - server player-connected checks
 
+Observability is a canonical semantic family owned by the host/runtime.
+In contract v1, observability currently contains only logging:
+
+- `RuntimeObservabilityRequest::Log(LogPayload)`
+- `LogPayload.level`
+- `LogPayload.message`
+
+Canonical log levels are:
+
+- `debug`
+- `info`
+- `warn`
+- `error`
+
+Logging is intentionally outside gameplay/result/effect semantics:
+
+- it is fire-and-forget from the guest perspective
+- it is not part of `ActionResult`
+- it is not part of `LifecycleResult`
+- it is not part of canonical message output
+- sink failures, filtering, or suppression do not become gameplay protocol
+
+The canonical guest log payload is intentionally minimal:
+
+- severity/level
+- UTF-8 message text
+
+Guests do not define custom categories, arbitrary key/value fields, trace/span
+ids, or sink selection in this phase. The host/runtime owns attribution,
+formatting, routing, filtering, truncation, and final presentation.
+
 Current command families include:
 
 - `RuntimeCommandOutput.world`
@@ -170,6 +202,7 @@ Current command families include:
 
 Transport adapters must carry these semantic families unchanged. They must not
 invent transport-specific truth about reads, messages, or command application.
+The same rule applies to observability/logging.
 
 ## Disable-on-session semantics
 
@@ -189,6 +222,30 @@ Guest SDKs may keep per-session state, but that state is scoped to the
 `StartInput.session` identity and must be discarded when a new session id is
 started.
 
+Observability/logging is also session-bound:
+
+- log capability exists only while the guest instance is bound to the active
+  runtime session
+- after disable-for-session, later log emissions from that guest/session must
+  be rejected or ignored by the host
+- after unload, detach, hot reload, world reload, or reattach, the old session
+  binding must no longer be accepted for further logs
+- transport carriers must not keep stale log handles/channels alive after
+  session end
+
+For every accepted guest log record, the host/runtime enriches the record with
+runtime-owned attribution where available:
+
+- mod/guest identity
+- execution kind
+- side
+- runtime session identity
+- runtime source/artifact/trust/policy context
+- active callback family or phase when honestly available
+
+Guests must not be required to prefix messages manually with their own runtime
+identity/context.
+
 If a guest violates the contract or faults during a runtime session:
 
 - that guest is disabled for the remainder of the runtime session
@@ -203,3 +260,15 @@ declared runtime commands after the `ActionResult` is decoded and validated.
 
 For message callbacks, faults include invalid inbound scope mapping and
 outbound sends that violate the negotiated channel/message contract.
+
+For observability/logging, ordinary host policy outcomes are not session faults:
+
+- oversized messages may be truncated
+- debug visibility may be suppressed
+- rate-limited records may be dropped or summarized
+
+True boundary violations in the logging path are session faults:
+
+- malformed transport envelopes
+- invalid enum or impossible payload shapes
+- adapter/bridge misuse that breaks the logging contract

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -137,6 +137,35 @@ Native guests can issue canonical runtime service requests through the installed
 The bridge is transport plumbing only. It must not redefine the semantic
 service families documented in `freven_guest`.
 
+Observability/logging uses that same canonical service surface:
+
+- request: `RuntimeServiceRequest::Observability(RuntimeObservabilityRequest::Log(LogPayload))`
+- payload: `LogPayload { level, message }`
+- levels: `debug`, `info`, `warn`, `error`
+
+Native transport does not get a separate privileged logging meaning. The guest
+provides only log level and UTF-8 message text. The host/runtime owns
+attribution, policy, sanitization, truncation, rate limiting, routing, and
+presentation.
+
+Every accepted native guest log is enriched host-side where available with mod
+identity, execution kind (`native`), side, runtime session id, source,
+artifact, trust, policy, and active callback family.
+
+Logging is fire-and-forget and remains outside gameplay semantics:
+
+- not part of `ActionResult`
+- not part of `LifecycleResult`
+- not part of message/output semantics
+
+Session enforcement is canonical rather than native-specific:
+
+- a native guest may log only while its active runtime-session binding is alive
+- after disable-for-session or session teardown, stale bridges/handles must no
+  longer produce accepted logs
+- malformed logging requests or bridge misuse are contract faults that may
+  disable the guest for the current runtime session
+
 ## Safety model
 
 Native mods are UNSAFE by design:

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -69,6 +69,9 @@ Optional runtime-service import:
 - host returns `u32::MAX` when the current host context does not expose runtime
   services
 
+The Wasm hostcall is transport plumbing only. Observability/logging semantics
+come from `freven_guest`, not from the Wasm ABI.
+
 ## Encoding
 
 ABI payloads are `postcard` encoded values from `freven_guest`.
@@ -154,6 +157,41 @@ Current message families:
 Host applies runtime commands through authoritative host services. Any
 decode/trap/validation/apply failure disables that guest for the runtime
 session.
+
+## Observability / logging
+
+Wasm guests emit logs through the same canonical runtime-service family used by
+other guest transports:
+
+- request: `RuntimeServiceRequest::Observability(RuntimeObservabilityRequest::Log(LogPayload))`
+- payload: `LogPayload { level, message }`
+- levels: `debug`, `info`, `warn`, `error`
+
+The payload remains intentionally minimal. The guest provides only level and
+message text. The host/runtime owns attribution, filtering, truncation, rate
+limiting, formatting, and sink routing.
+
+Accepted log records are enriched host-side with runtime context where
+available, including mod identity, execution kind (`wasm`), side, runtime
+session id, source/artifact/trust/policy metadata, and active callback family.
+
+Logging is fire-and-forget:
+
+- it does not change action/lifecycle/message semantics
+- it is not part of `ActionResult` or `LifecycleResult`
+- host sink failures or filtering do not become gameplay protocol
+
+Session enforcement matches the canonical runtime-session model:
+
+- a Wasm instance may log only while its current runtime session is alive
+- after disable-for-session, detach, unload, hot reload, world reload, or
+  reattach, old log emissions must no longer be accepted
+- malformed service payloads or impossible logging requests are contract faults
+  and may disable the guest for that runtime session
+
+Host policy may suppress debug logs by default, safely truncate oversized
+messages, sanitize dirty/control-heavy text, and drop/summarize spam without
+crashing or destabilizing the runtime.
 
 ## Capability policy (implemented in `freven_runtime_wasm`)
 


### PR DESCRIPTION
## Summary

This PR adds the public SDK contract for canonical observability, starting with logging.

It defines the shared types and bridge surface used by builtin code and guest runtimes so logs can be emitted through one runtime-owned semantic model instead of transport-specific mechanisms.

## What changed

- added canonical observability/logging types to the public API
- introduced:
  - `LogLevel`
  - `LogPayload`
  - `RuntimeObservabilityRequest`
  - `HostLogContext`
  - `HostLogRecord`
  - `ObservabilityBridge`
- exposed logging helpers through `freven_api` and `freven_guest_sdk`
- added `emit_log(...)` support to server/client/action/message/tick APIs
- extended `RuntimeServiceRequest` / `RuntimeServiceResponse` with observability support
- added shared SDK observability types to `freven_sdk_types`
- documented canonical logging semantics for:
  - guest contract
  - Wasm ABI
  - native ABI
  - external IPC

## Why

The runtime now needs one stable public contract for observability that works the same way across builtin, Wasm, native, and external execution.

This PR defines that contract with a deliberately minimal guest payload:
- log level
- UTF-8 message text

Everything else — attribution, session context, source metadata, filtering, truncation, rate limiting, and presentation — remains host-owned.

## Result

The public API/ABI now has a canonical observability surface that transport adapters can carry without redefining logging semantics.