### PR TITLE
feat(guest_sdk): add log_debug/info/warn/error macros over canonical observability API

### DIFF
--- a/crates/freven_guest_sdk/src/lib.rs
+++ b/crates/freven_guest_sdk/src/lib.rs
@@ -1559,6 +1559,47 @@ impl RuntimeServices {
     }
 }
 
+/// Emit a log message through the canonical guest observability service.
+///
+/// Prefer [`log_debug!`], [`log_info!`], [`log_warn!`], [`log_error!`] over
+/// calling this directly.
+#[doc(hidden)]
+pub fn __guest_emit_log(level: LogLevel, args: ::core::fmt::Arguments<'_>) {
+    RuntimeServices.log(level, ::alloc::format!("{args}"));
+}
+
+/// Log a debug message from a guest mod.
+#[macro_export]
+macro_rules! log_debug {
+    ($($arg:tt)*) => {
+        $crate::__guest_emit_log($crate::LogLevel::Debug, ::core::format_args!($($arg)*));
+    };
+}
+
+/// Log an info message from a guest mod.
+#[macro_export]
+macro_rules! log_info {
+    ($($arg:tt)*) => {
+        $crate::__guest_emit_log($crate::LogLevel::Info, ::core::format_args!($($arg)*));
+    };
+}
+
+/// Log a warning from a guest mod.
+#[macro_export]
+macro_rules! log_warn {
+    ($($arg:tt)*) => {
+        $crate::__guest_emit_log($crate::LogLevel::Warn, ::core::format_args!($($arg)*));
+    };
+}
+
+/// Log an error from a guest mod.
+#[macro_export]
+macro_rules! log_error {
+    ($($arg:tt)*) => {
+        $crate::__guest_emit_log($crate::LogLevel::Error, ::core::format_args!($($arg)*));
+    };
+}
+
 pub struct ActionResponse;
 
 pub struct AppliedActionResponse {

--- a/crates/freven_guest_sdk/tests/log_macros.rs
+++ b/crates/freven_guest_sdk/tests/log_macros.rs
@@ -1,0 +1,23 @@
+use freven_guest_sdk::{log_debug, log_error, log_info, log_warn};
+
+#[test]
+fn log_macros_expand_without_panic() {
+    // no runtime bridge installed — calls are fire-and-forget no-ops here
+    log_debug!("debug message");
+    log_info!("info message");
+    log_warn!("warn message");
+    log_error!("error message");
+}
+
+#[test]
+fn log_macros_accept_format_args() {
+    let x = 42u32;
+    log_info!("value is {}", x);
+    log_warn!("coords {:?}", (1, 2, 3));
+}
+
+#[test]
+fn log_macros_accept_trailing_comma() {
+    log_debug!("trailing comma",);
+    log_info!("also fine {}", 1,);
+}

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -12,18 +12,20 @@ Wasm ABI exports.
   model visible while hiding export-table, allocation, and `postcard` plumbing.
 - Raw ABI work is still available for fixtures and runtime validation, but it is
   not the normal getting-started experience.
+- Builtin / compile-time mods use `freven_mod_api`, but they still participate
+  in the same semantic registration and runtime-output model.
 
 ## Canonical lifecycle in guest contract v1
 
 The canonical guest lifecycle today is:
 
 - negotiation
-- `on_start_client`
-- `on_start_server`
-- `on_tick_client`
-- `on_tick_server`
-- `on_client_messages`
-- `on_server_messages`
+- `start_client`
+- `start_server`
+- `tick_client`
+- `tick_server`
+- client message callbacks
+- server message callbacks
 - action handling through one action entrypoint plus declared bindings
 
 Current contract shape:
@@ -34,8 +36,9 @@ Current contract shape:
 - all three callback families emit the same `RuntimeOutput` families
 - `on_start_common` is not part of the runtime-loaded guest contract
 
-Those boundaries are intentional. The SDK does not pretend lifecycle output or
-cross-transport parity exists when it does not.
+Those boundaries are intentional. The public story is one semantic model, but
+the transport references remain transport-specific where the encoding actually
+differs.
 
 ## Minimal authoring example
 
@@ -88,11 +91,12 @@ hooks and action bindings you write are the same data used to build the
 canonical `GuestDescription` and to emit the Wasm export table, so the two
 surfaces cannot drift in normal authoring.
 
-The canonical registration model now includes blocks, components, messages,
+The canonical registration model includes blocks, components, messages,
 channels, actions, capabilities, worldgen keys, character-controller keys, and
-client-control-provider keys. Wasm guests may declare the provider families,
-but the runtime still policy-gates them explicitly because guest-side provider
-hosting is not implemented yet.
+client-control-provider keys. Wasm guests may declare provider families, and
+the runtime now hosts them through the same semantic registration model used by
+builtin, native, and external execution. Side and policy still gate which
+providers are actually hosted in a given runtime session.
 
 `GuestModule` plus `export_wasm_guest!(...)` still exist as a lower-level escape
 hatch for raw ABI fixtures, runtime validation, or unusual tests, but they are
@@ -137,7 +141,7 @@ Two SDK hardening rules matter here:
 The config document is the resolved per-mod `experience.config."<mod_id>"`
 table serialized as TOML text. `freven_guest_sdk::StartInputExt` exposes
 `config_text()` and `config_typed::<T>()` helpers so guest authors can read the
-same per-mod config semantics compile-time mods already had.
+same per-mod config semantics builtin / compile-time mods already had.
 
 ## Runtime services
 
@@ -151,6 +155,30 @@ same per-mod config semantics compile-time mods already had.
 These calls are semantic runtime services. They are not ad-hoc callback hacks
 and they are not encoded as fake action results.
 
+## Logging
+
+Use the log macros from `freven_guest_sdk` to emit messages through the
+canonical observability service:
+```rust
+use freven_guest_sdk::{log_debug, log_info, log_warn, log_error};
+
+// inside any lifecycle, action, or message callback:
+log_info!("player {} joined the world", player_id);
+log_warn!("block at {:?} was already air", pos);
+```
+
+All four levels are available: `log_debug!`, `log_info!`, `log_warn!`,
+`log_error!`. They accept the same format syntax as `format!`.
+
+Logging is fire-and-forget: it does not affect `ActionResult`,
+`LifecycleResult`, or message output. The host owns attribution, filtering,
+routing, and presentation — guests provide only level and message text.
+
+The macros call `RuntimeServices.log(...)` under the hood, which routes through
+`RuntimeServiceRequest::Observability`. On Wasm this goes through
+`freven_guest_host_service_call`; on native it goes through
+`NativeRuntimeBridge`. The guest code is identical across transports.
+
 ## Transport guidance
 
 Prefer these paths in this order:
@@ -162,6 +190,11 @@ Prefer these paths in this order:
 Native and external paths are secondary today. They remain important for
 specific cases, but they should not be presented as equivalent onboarding paths
 or as safer alternatives to Wasm.
+
+Builtin / compile-time execution is the same semantic system through a
+different execution path. It is not a transport rival to Wasm; use
+`freven_mod_api` when you are authoring code that ships builtin with the
+experience or host.
 
 ## Reference docs
 


### PR DESCRIPTION
SDK ergonomics layer on top of the canonical observability contract landed in #19.

Adds `__guest_emit_log` as an internal dispatch helper over `RuntimeServices::log`, and `log_debug!`, `log_info!`, `log_warn!`, `log_error!` macros with `format!`-style syntax for guest mod authors.

Also adds a Logging section to `docs/WASM_AUTHORING.md`.

Closes https://github.com/frevenengine/freven-devkit/issues/4

## Validation
List what you ran:
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo test --workspace --all-features

## freven-sdk dependency
- Does this PR change the pinned `freven-sdk` tag?
  - [x] No
  - [ ] Yes (which tag and why?)

## Notes for reviewers
Anything risky, subtle, or worth double-checking?

No new contract surface. Macros are a thin ergonomics layer over RuntimeServices::log which routes through RuntimeServiceRequest::Observability as already documented in GUEST_CONTRACT_v1.md.