### PR TITLE
Add capability declarations to freven_mod_api

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Start with [docs/WASM_AUTHORING.md](docs/WASM_AUTHORING.md).
   as equal onboarding stories.
 - Treat builtin mods as the same semantic system through a different execution
   path, not as a separate mod model.
+- `freven_mod_api` now covers the full declaration families exposed publicly:
+  blocks, components, messages, channels, actions, capabilities, providers,
+  and lifecycle hooks.
 
 ## Depend on the SDK today
 

--- a/crates/freven_mod_api/README.md
+++ b/crates/freven_mod_api/README.md
@@ -12,11 +12,17 @@ and the recommended public authoring path is `freven_guest_sdk` on Wasm.
 `freven_mod_api` still participates in the same semantic system:
 
 - deterministic registration via `ModContext`
+- canonical capability declarations via `ModContext::declare_capability(...)`
 - activation hooks via `on_start_client` / `on_start_server`
 - runtime hooks via `on_tick_client` / `on_tick_server`
 - dedicated client/server message phases
 - the same declaration families, runtime output model, and observability model
   used by runtime-loaded guests
+
+Builtin / compile-time capability declarations use the same
+`CapabilityDeclaration` model as `freven_guest`. When a builtin mod is hosted
+from a resolved `mod.toml`, declared capability keys are validated against that
+resolved capability table before the runtime records them.
 
 `ExperienceSpec` in this crate is a compile-time convenience surface. Canonical
 boot/load/runtime truth lives in the engine runtime activation model, not here.

--- a/crates/freven_mod_api/src/lib.rs
+++ b/crates/freven_mod_api/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Responsibilities:
 //! - define experience/mod descriptors used by boot/runtime layers
-//! - expose deterministic registration surfaces (components/messages/worldgen/modnet)
+//! - expose deterministic registration surfaces (components/messages/worldgen/modnet/capabilities)
 //! - define stable hook contexts and registration errors
 //! - act as the builtin / compile-time facade over the canonical declaration model exposed by `freven_guest`
 //!
@@ -16,7 +16,7 @@ use std::{cell::RefCell, ffi::c_void, sync::Arc, time::Duration};
 use serde::de::DeserializeOwned;
 
 pub use freven_guest::{
-    CharacterControllerDeclaration, ClientControlProviderDeclaration,
+    CapabilityDeclaration, CharacterControllerDeclaration, ClientControlProviderDeclaration,
     ClientNameplateDrawCmd as GuestClientNameplateDrawCmd,
     ClientPlayerView as GuestClientPlayerView, GuestCallbacks as ModCallbackModel,
     GuestRegistration as ModDeclarationModel, LifecycleHooks as LifecycleCallbackModel, LogLevel,
@@ -317,6 +317,10 @@ pub trait ModContextBackend {
         handler: Box<dyn ActionHandler>,
     ) -> Result<(), ModRegistrationError>;
     fn register_action_kind(&mut self, key: &str) -> Result<ActionKindId, ModRegistrationError>;
+    fn declare_capability(
+        &mut self,
+        capability: CapabilityDeclaration,
+    ) -> Result<(), ModRegistrationError>;
     fn on_start_client(&mut self, hook: StartClientHook);
     fn on_start_server(&mut self, hook: StartServerHook);
     fn on_tick_client(&mut self, hook: TickClientHook);
@@ -469,6 +473,19 @@ impl<'a> ModContext<'a> {
         self.backend.register_action_kind(key)
     }
 
+    pub fn declare_capability(&mut self, key: &str) -> Result<(), ModRegistrationError> {
+        self.declare_capability_declaration(CapabilityDeclaration {
+            key: key.to_string(),
+        })
+    }
+
+    pub fn declare_capability_declaration(
+        &mut self,
+        capability: CapabilityDeclaration,
+    ) -> Result<(), ModRegistrationError> {
+        self.backend.declare_capability(capability)
+    }
+
     pub fn on_start_client(&mut self, hook: StartClientHook) {
         self.backend.on_start_client(hook);
     }
@@ -592,6 +609,28 @@ pub enum ModRegistrationError {
         kind: &'static str,
         reason: String,
     },
+}
+
+pub fn validate_capability_declaration(
+    mod_id: &str,
+    capability: &CapabilityDeclaration,
+    allowed: Option<&toml::Table>,
+) -> Result<(), ModRegistrationError> {
+    if capability.key.trim().is_empty() {
+        return Err(ModRegistrationError::EmptyKey {
+            mod_id: mod_id.to_string(),
+            registry: "capability",
+        });
+    }
+    if let Some(allowed) = allowed
+        && !allowed.contains_key(&capability.key)
+    {
+        return Err(ModRegistrationError::UndeclaredCapability {
+            mod_id: mod_id.to_string(),
+            key: capability.key.clone(),
+        });
+    }
+    Ok(())
 }
 
 /// Error type for mod config decode failures.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,4 +14,5 @@ Read them in this order:
 - [UNSAFE_NATIVE_MODS.md](UNSAFE_NATIVE_MODS.md): native trust / policy notes
 
 `freven_mod_api` is the builtin / compile-time facade over the same semantic
-system. `freven_guest` remains the canonical runtime-loaded guest contract.
+system, including capability declarations through `ModContext::declare_capability`.
+`freven_guest` remains the canonical runtime-loaded guest contract.


### PR DESCRIPTION
## Summary
This PR extends `freven_mod_api` so builtin / compile-time mods can declare capabilities through the same public semantic model used by runtime-loaded guests.

## What changed
- re-export `CapabilityDeclaration` from `freven_guest`
- add `ModContext::declare_capability(...)`
- add `ModContext::declare_capability_declaration(...)`
- extend `ModContextBackend` with capability-declaration support
- expose shared `validate_capability_declaration(...)` validation logic in the public SDK surface
- update SDK docs and README text to describe capability declarations as part of the public builtin semantic surface

## Why
`freven_mod_api` already covered the main public declaration families, but capability declarations were still missing as a first-class builtin API surface. That left an avoidable mismatch between builtin authoring and guest authoring. This PR fixes that gap so builtin mods participate in the same capability declaration model, terminology, and validation story as the rest of the public Freven SDK.