### PR TITLE
relicense freven-sdk under Apache-2.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,36 +1,50 @@
 # Contributing to Freven SDK
 
-This repository is **readable source** under the Freven Readable Source License (FRSL).
-**Redistribution, mirroring, and public forks are not permitted by the license.**
+Thanks for your interest in contributing.
+
+## Ground rules
+
+- Keep changes scoped and intentional.
+- Prefer small, reviewable pull requests.
+- Discuss large architectural changes before implementing them.
+- Follow existing crate/layer boundaries and public contract direction.
 
 ## What contributions are accepted
+
 - Bug fixes
 - Documentation improvements
-- Small, well-scoped improvements to SDK ergonomics
-- ABI/docs clarifications
+- Small, well-scoped SDK ergonomics improvements
+- Contract / ABI / docs clarifications
+- Tests and validation improvements
 
 ## What contributions are NOT accepted
-- Requests to open-source the engine or change the licensing model
+
 - Large refactors without prior discussion
-- "Rewrite the world" PRs that touch many files without a clear reason
+- Broad "rewrite everything" pull requests without a clear architectural reason
+- Changes that collapse the neutral SDK roots and explicit world-owned SDK surfaces back into one mixed surface
 
 ## How to contribute
-- Contributions are accepted **only via Pull Requests** to the official upstream repository.
-- Keep PRs small and focused (one change = one PR).
-- Include tests or a clear validation story.
 
-## By contributing
-By submitting a PR, you confirm you have the right to contribute the code and you agree that
-your contribution may be used, modified, and relicensed by Freven as part of the project
-(as described in the repository LICENSE).
+- Contributions are accepted via Pull Requests to the official upstream repository.
+- Keep PRs small and focused.
+- Include tests or a clear validation story when behavior changes.
+- Update docs/examples when public SDK behavior changes.
+
+## Licensing
+
+By intentionally submitting a contribution to this repository, you agree that
+your contribution is provided under the same license as this repository,
+Apache License 2.0, unless explicitly stated otherwise.
 
 ## Local checks before opening a PR
+
 Run:
-- `cargo fmt --all -- --check`
+
+- `cargo fmt --all --check`
 - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 - `cargo test --workspace --all-features`
 
 ## SDK tags / versioning policy
-- If a PR changes the public contracts in `freven_api`, `freven_sdk_types`, or `freven_std`,
-  it requires a **version bump** and a **new git tag** (e.g. `v0.1.1`).
-- Downstream repos (like `freven-vanilla`) must update dependencies **only via tags**.
+
+- If a PR changes public SDK contracts or public author-facing behavior, it may require a version bump and a new git tag.
+- Downstream repositories should prefer tagged SDK versions over floating revisions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 [workspace.package]
 edition = "2024"
 version = "0.1.0"
-license = "LicenseRef-FRSL-1.0"
+license = "Apache-2.0"
 repository = "https://github.com/frevenengine/freven-sdk"
 homepage = "https://github.com/frevenengine/freven-sdk"
 documentation = "https://github.com/frevenengine/freven-sdk/tree/main/docs"

--- a/LICENSE
+++ b/LICENSE
@@ -1,27 +1,202 @@
-Freven Readable Source License (FRSL) v1.0
 
-Copyright (c) 2026 Freven.
-All rights reserved.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-This is proprietary software made publicly readable.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-You are granted permission to:
-1) View, download, and compile this source code for personal use.
-2) Use this source code as a reference to develop mods/experiences for the Freven engine.
-3) Submit contributions (pull requests) to the official upstream repository.
+   1. Definitions.
 
-You are NOT granted permission to:
-A) Redistribute this source code (modified or unmodified) in whole or in part.
-B) Publish mirrors, forks, re-uploads, or copies of this repository or its contents.
-C) Distribute derivative works of this codebase as a standalone product (including “my fork” releases).
-D) Publish this code to package registries (e.g., crates.io) or other distribution channels.
-E) Use this code to create or ship a competing engine/game SDK or a substantially similar product.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-Contributions:
-By submitting a contribution to the official upstream repository, you grant Freven
-a perpetual, worldwide, royalty-free license to use, modify, and relicense your
-contribution as part of the Freven project.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-No trademark rights are granted. “Freven” and related marks remain proprietary.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+Freven SDK
+Copyright 2026 Freven
+
+This product includes software developed as part of the Freven SDK project.
+
+Licensed under the Apache License, Version 2.0.
+You may obtain a copy of the License at:
+    http://www.apache.org/licenses/LICENSE-2.0
+
+See the LICENSE file for the full license text.

--- a/README.md
+++ b/README.md
@@ -75,3 +75,13 @@ See [docs/SDK_DISTRIBUTION.md](docs/SDK_DISTRIBUTION.md) for release policy.
 - SDK is pre-1.0.
 - Breaking changes will be called out in release notes.
 - Experimental areas are labeled explicitly in docs and code.
+
+## License
+
+This repository is licensed under the Apache License, Version 2.0.
+See `LICENSE` for the full text.
+
+`freven-sdk` contains the public Freven SDK for mod and experience authoring.
+
+Freven engine internals remain private and are not part of this repository.
+Other Freven repositories may use different licenses.


### PR DESCRIPTION
## Summary

Relicense `freven-sdk` from FRSL to Apache-2.0.

This changes the public SDK repository to a real open-source license while
keeping Freven engine internals private and leaving other Freven repositories
free to use different licenses.

## What changed

- changed workspace license from `LicenseRef-FRSL-1.0` to `Apache-2.0`
- replaced the repository `LICENSE` file with the Apache License 2.0 text
- added `NOTICE`
- updated `.github/CONTRIBUTING.md` to match the new license model
- added a `License` section to the root `README.md`

## Why

`freven-sdk` is the public SDK / contract layer for mod and experience authoring.
Apache-2.0 fits that role better than a readable-source license:

- the public SDK is now clearly open-source
- downstream tooling and integrations have a standard OSS license story
- contribution terms are simpler and aligned with the repository license
- this matches the long-term direction where the SDK is a public platform surface,
  while engine internals remain private

## Scope

This PR only changes licensing and repository metadata for `freven-sdk`.

It does **not**:
- open-source the engine
- change `freven-vanilla` licensing
- change public SDK semantics or architecture

## Validation

Ran successfully:

- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

Also verified:

- workspace manifests now resolve to `Apache-2.0`
- old FRSL / readable-source wording was removed from the repository

## Notes

`cargo package --workspace` still does not fully verify the whole workspace due to
the existing unpublished internal dependency chain between workspace crates.
That is a separate packaging/publishing concern and is unrelated to this
licensing change.