### PR TITLE
refresh freven-sdk README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,113 @@
 # Freven SDK
 
-This repository contains the public Freven SDK for mod and experience authoring.
-The engine source is private and is not part of this repository.
+`freven-sdk` is the public SDK and contract surface for Freven mod and experience authoring.
 
-## Public crates
+Freven is being built as a **platform for experiences**:
+- a neutral platform layer
+- optional world/game stacks layered on top
+- concrete first-party or third-party experiences
+- future mod/module/service composition above those layers
 
-- `freven_guest_sdk`: high-level neutral guest SDK for the public Wasm path
-- `freven_guest`: neutral transport-agnostic guest contract for runtime-loaded mods
-- `freven_mod_api`: builtin / compile-time facade over the same semantic model
-- `freven_sdk_types`: neutral shared SDK types and observability helpers
-- `freven_world_guest_sdk`: explicit world-owned guest authoring surface
-- `freven_world_guest`: explicit world-owned runtime-loaded world contract
-- `freven_world_api`: explicit world-owned builtin / compile-time facade
-- `freven_world_sdk_types`: explicit world-owned block/voxel shared types
+This repository contains the public author-facing SDK for that direction.
+Freven engine internals remain private and are **not** part of this repository.
+
+## Repository role
+
+`freven-sdk` is the public contract layer of Freven.
+
+It is responsible for:
+- guest-facing APIs
+- public authoring surfaces
+- shared SDK contracts and types
+- public Wasm mod authoring
+- builtin / compile-time integration surfaces
+- explicit world-owned SDK overlays above the neutral SDK roots
+
+It is **not**:
+- the engine implementation
+- the first-party Vanilla gameplay repository
+- the full Freven runtime host
+- the full Freven world/game stack implementation
+
+## Freven architecture at a glance
+
+The current long-term direction is:
+
+- **engine/platform layer**: neutral runtime/platform substrate
+- **world stacks**: explicit world/game-specific layers above the platform
+- **experiences**: concrete games or modes built on top
+- **mods/modules/services**: extension units that can evolve into a broader ecosystem
+
+Within that model:
+
+- `freven-sdk` provides the **public SDK surface**
+- `freven-vanilla` provides the **first-party reference experience**
+- Freven engine internals remain private
+
+## Public SDK surfaces
+
+The repository currently exposes two kinds of public SDK surface:
+
+### Neutral SDK roots
+
+These cover generic platform-shaped authoring concerns.
+
+- `freven_guest_sdk` — high-level neutral guest SDK for the public Wasm path
+- `freven_guest` — neutral transport-agnostic guest contract for runtime-loaded mods
+- `freven_mod_api` — builtin / compile-time facade over the same neutral semantic model
+- `freven_sdk_types` — neutral shared SDK types and observability helpers
+
+### Explicit world-owned SDK roots
+
+These cover the current world/game-stack-shaped public surfaces.
+
+- `freven_world_guest_sdk` — explicit world-owned guest authoring surface
+- `freven_world_guest` — explicit world-owned runtime-loaded world contract
+- `freven_world_api` — explicit world-owned builtin / compile-time facade
+- `freven_world_sdk_types` — explicit world-owned block/voxel shared types
 
 `freven_api` has been retired. The public crate name is now `freven_mod_api`
 so the builtin / compile-time surface is not mistaken for the whole SDK.
 
-Reference gameplay lives in the separate `freven-vanilla` repository. Stage 01
-of the platform boundary reset removed block, voxel, controller, world-query,
-world-command, and first-party gameplay helpers from the neutral SDK roots.
-Vanilla-owned break/place payload helpers, humanoid input codecs, and first-party
-ids now live in `freven-vanilla`, not in the SDK repository.
+## How to think about the split
 
-## Recommended authoring path
+The important rule is:
+
+- neutral SDK roots describe **platform-shaped** concepts
+- `freven_world_*` roots describe **explicit world-owned** concepts
+
+That means block/voxel/world-specific authoring is no longer presented as the neutral top-level SDK story.
+
+Reference first-party gameplay lives in the separate `freven-vanilla` repository.
+Vanilla-owned break/place payload helpers, humanoid input codecs, and first-party ids
+do **not** live in the neutral SDK roots.
+
+## Which path should authors use?
 
 Start with [docs/WASM_AUTHORING.md](docs/WASM_AUTHORING.md).
 
-- Use `freven_guest_sdk` for neutral runtime-loaded guests that need only
-  lifecycle, messages, components, channels, capabilities, session identity,
-  and observability.
-- Use `freven_world_guest_sdk` for runtime-loaded gameplay/world-stack mods.
-- Treat Wasm as the polished safe public path.
-- Treat `freven_guest` plus
-  [docs/NEUTRAL_GUEST_CONTRACT_v1.md](docs/NEUTRAL_GUEST_CONTRACT_v1.md) as
-  low-level neutral reference material for fixtures, runtime work, and
-  contract adapters.
-- Treat `freven_world_guest` plus the ABI / IPC docs as low-level explicit
-  world-stack reference material.
-- Use `freven_mod_api` for builtin / compile-time neutral integrations.
-- Use `freven_world_api` for builtin / compile-time gameplay/world authoring.
-- Treat the `freven_world_*` crates as explicit world-owned overlays over the
-  neutral SDK roots, not as replacement top-level SDK monoliths.
-- Treat native and external execution as secondary trust / execution paths, not
-  as equal onboarding stories.
-- Treat builtin mods as the same semantic system through a different execution
-  path, not as a separate mod model.
-- Neutral roots now cover generic lifecycle, components, messages, channels,
-  capabilities, session identity, and observability. World-shaped declarations
-  live behind explicit `freven_world_*` ownership.
+Recommended path:
+
+- use **`freven_guest_sdk`** for neutral runtime-loaded Wasm guests
+- use **`freven_world_guest_sdk`** for current gameplay/world-stack mods
+- treat **Wasm** as the polished safe public path
+- treat **native/external execution** as secondary trust / execution paths, not as equal onboarding stories
+- treat **builtin / compile-time mods** as the same semantic model through a different execution path, not as a separate mod model
+
+## Which crate should I pick?
+
+Use:
+
+- **`freven_guest_sdk`** if you need lifecycle, messages, components, channels, capabilities, session identity, and observability
+- **`freven_world_guest_sdk`** if you are writing a runtime-loaded gameplay/world-stack mod against the current world surface
+- **`freven_mod_api`** for builtin / compile-time neutral integrations
+- **`freven_world_api`** for builtin / compile-time gameplay/world authoring
+- **`freven_guest`** only when you need the low-level neutral contract directly
+- **`freven_world_guest`** only when you need the low-level explicit world contract directly
+
+For most public runtime-loaded mod authors, the intended starting point is:
+- `freven_guest_sdk`, or
+- `freven_world_guest_sdk`
 
 ## Depend on the SDK today
 
@@ -56,32 +115,36 @@ Use tagged git dependencies until crates.io publishing begins:
 
 ```toml
 [dependencies]
-freven_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_guest_sdk" }
-freven_mod_api = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_mod_api" }
-freven_sdk_types = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_sdk_types" }
+freven_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_guest_sdk" }
+freven_mod_api   = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_mod_api" }
+freven_sdk_types = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_sdk_types" }
 
 # Low-level guest contract work only:
-# freven_guest = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_guest" }
+# freven_guest = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_guest" }
 
 # Current world-stack integrations only:
-# freven_world_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_world_guest_sdk" }
-# freven_world_api = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_world_api" }
-```
+# freven_world_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_world_guest_sdk" }
+# freven_world_api       = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_world_api" }
+````
 
 See [docs/SDK_DISTRIBUTION.md](docs/SDK_DISTRIBUTION.md) for release policy.
 
-## Stability notes
+## Current status
 
-- SDK is pre-1.0.
-- Breaking changes will be called out in release notes.
-- Experimental areas are labeled explicitly in docs and code.
+* the SDK is pre-1.0
+* breaking changes will be called out in release notes
+* experimental areas are labeled explicitly in docs and code
+* the public Wasm path is the recommended public authoring path today
+* engine internals remain private
+* other Freven repositories may use different licenses
+
+## Related repositories
+
+* `freven-sdk` — public SDK and contract surface
+* `freven-vanilla` — first-party reference experience
+* Freven engine repositories — private implementation/runtime side
 
 ## License
 
 This repository is licensed under the Apache License, Version 2.0.
-See `LICENSE` for the full text.
-
-`freven-sdk` contains the public Freven SDK for mod and experience authoring.
-
-Freven engine internals remain private and are not part of this repository.
-Other Freven repositories may use different licenses.
+See [LICENSE](LICENSE) for the full text.


### PR DESCRIPTION
## Summary

Refresh the root `freven-sdk` README so the repository is easier to understand
for first-time visitors.

The updated README explains:
- what Freven is at a high level
- the role of `freven-sdk` in the broader Freven architecture
- the split between neutral SDK roots and explicit world-owned SDK roots
- the recommended public authoring path
- how `freven-sdk` relates to private engine internals and `freven-vanilla`

## What changed

- rewrote the root README for clearer external positioning
- added a short architecture-at-a-glance section
- clarified the repository role of `freven-sdk`
- clarified the neutral vs world-owned public SDK split
- clarified which crates authors should start with
- updated the dependency example to the current tagged SDK line
- kept the Apache-2.0 license section in the README

## Why

The previous README was accurate, but it assumed too much prior context.

This refresh makes the repository more legible to:
- first-time SDK users
- mod and experience authors
- people evaluating Freven's public SDK surface
- external reviewers looking at the project structure

## Scope

This PR changes documentation only.

It does **not**:
- change SDK semantics
- change public contracts
- change runtime behavior
- change licensing beyond the already-landed Apache-2.0 transition

## Notes

The intended public starting points remain:
- `freven_guest_sdk` for the neutral Wasm path
- `freven_world_guest_sdk` for current gameplay/world-stack mods