### PR TITLE
Normalize freven-sdk repository URLs in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,16 +115,16 @@ Use tagged git dependencies until crates.io publishing begins:
 
 ```toml
 [dependencies]
-freven_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_guest_sdk" }
-freven_mod_api   = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_mod_api" }
-freven_sdk_types = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_sdk_types" }
+freven_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk.git", tag = "v0.1.2-rc3", package = "freven_guest_sdk" }
+freven_mod_api   = { git = "https://github.com/frevenengine/freven-sdk.git", tag = "v0.1.2-rc3", package = "freven_mod_api" }
+freven_sdk_types = { git = "https://github.com/frevenengine/freven-sdk.git", tag = "v0.1.2-rc3", package = "freven_sdk_types" }
 
 # Low-level guest contract work only:
-# freven_guest = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_guest" }
+# freven_guest = { git = "https://github.com/frevenengine/freven-sdk.git", tag = "v0.1.2-rc3", package = "freven_guest" }
 
 # Current world-stack integrations only:
-# freven_world_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_world_guest_sdk" }
-# freven_world_api       = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.2-rc3", package = "freven_world_api" }
+# freven_world_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk.git", tag = "v0.1.2-rc3", package = "freven_world_guest_sdk" }
+# freven_world_api       = { git = "https://github.com/frevenengine/freven-sdk.git", tag = "v0.1.2-rc3", package = "freven_world_api" }
 ````
 
 See [docs/SDK_DISTRIBUTION.md](docs/SDK_DISTRIBUTION.md) for release policy.

--- a/docs/SDK_DISTRIBUTION.md
+++ b/docs/SDK_DISTRIBUTION.md
@@ -39,12 +39,12 @@ Naming note:
 
 ```toml
 [dependencies]
-freven_mod_api = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_mod_api" }
-freven_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_guest_sdk" }
-freven_sdk_types = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_sdk_types" }
+freven_mod_api = { git = "https://github.com/frevenengine/freven-sdk.git", tag = "v0.1.0", package = "freven_mod_api" }
+freven_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk.git", tag = "v0.1.0", package = "freven_guest_sdk" }
+freven_sdk_types = { git = "https://github.com/frevenengine/freven-sdk.git", tag = "v0.1.0", package = "freven_sdk_types" }
 # Explicit world-owned surfaces when you intentionally target the current world stack:
-# freven_world_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_world_guest_sdk" }
-# freven_world_api = { git = "https://github.com/frevenengine/freven-sdk", tag = "v0.1.0", package = "freven_world_api" }
+# freven_world_guest_sdk = { git = "https://github.com/frevenengine/freven-sdk.git", tag = "v0.1.0", package = "freven_world_guest_sdk" }
+# freven_world_api = { git = "https://github.com/frevenengine/freven-sdk.git", tag = "v0.1.0", package = "freven_world_api" }
 ````
 
 Guidance:


### PR DESCRIPTION
Update the README and SDK distribution guide to use the canonical .git form for freven-sdk dependency URLs. This is a documentation-only cleanup that keeps installation examples consistent across the published guidance.