### PR TITLE
Add volumetric addressing foundation types to the SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[patch.unused]]
+name = "freven_vanilla_essentials"
+version = "0.1.0"
+
+[[patch.unused]]
 name = "freven_client_engine"
 version = "0.1.0"
 
@@ -367,8 +371,4 @@ version = "0.1.0"
 
 [[patch.unused]]
 name = "freven_world_runtime"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "freven_vanilla_essentials"
 version = "0.1.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,9 @@ dependencies = [
 [[package]]
 name = "freven_volumetric_sdk_types"
 version = "0.1.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "freven_world_api"
@@ -101,6 +104,7 @@ dependencies = [
  "freven_block_sdk_types",
  "freven_guest",
  "freven_sdk_types",
+ "freven_volumetric_sdk_types",
  "freven_world_sdk_types",
  "serde",
 ]
@@ -362,9 +366,9 @@ name = "freven_wasm_host"
 version = "0.1.0"
 
 [[patch.unused]]
-name = "freven_world_core"
+name = "freven_world_runtime"
 version = "0.1.0"
 
 [[patch.unused]]
-name = "freven_world_runtime"
+name = "freven_vanilla_essentials"
 version = "0.1.0"

--- a/crates/freven_volumetric_sdk_types/Cargo.toml
+++ b/crates/freven_volumetric_sdk_types/Cargo.toml
@@ -10,3 +10,4 @@ description = "Stable volumetric foundation SDK data contracts for Freven."
 publish = false
 
 [dependencies]
+serde.workspace = true

--- a/crates/freven_volumetric_sdk_types/src/addressing.rs
+++ b/crates/freven_volumetric_sdk_types/src/addressing.rs
@@ -1,0 +1,122 @@
+use serde::{Deserialize, Serialize};
+
+/// Absolute column coordinate in volumetric world space.
+///
+/// This is topology/addressing truth only. It does not imply any block gameplay semantics.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ColumnCoord {
+    pub cx: i32,
+    pub cz: i32,
+}
+
+impl ColumnCoord {
+    #[must_use]
+    pub const fn new(cx: i32, cz: i32) -> Self {
+        Self { cx, cz }
+    }
+}
+
+impl From<(i32, i32)> for ColumnCoord {
+    fn from(value: (i32, i32)) -> Self {
+        Self {
+            cx: value.0,
+            cz: value.1,
+        }
+    }
+}
+
+impl From<ColumnCoord> for (i32, i32) {
+    fn from(value: ColumnCoord) -> Self {
+        (value.cx, value.cz)
+    }
+}
+
+/// Vertical section coordinate in the canonical volumetric stack.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SectionY(pub i8);
+
+impl SectionY {
+    #[must_use]
+    pub const fn new(raw: i8) -> Self {
+        Self(raw)
+    }
+
+    #[must_use]
+    pub const fn raw(self) -> i8 {
+        self.0
+    }
+}
+
+impl From<i8> for SectionY {
+    fn from(value: i8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<SectionY> for i8 {
+    fn from(value: SectionY) -> Self {
+        value.0
+    }
+}
+
+/// Absolute section coordinate in volumetric world space.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SectionCoord {
+    pub cx: i32,
+    pub cz: i32,
+    pub sy: i8,
+}
+
+impl SectionCoord {
+    #[must_use]
+    pub const fn new(cx: i32, cz: i32, sy: i8) -> Self {
+        Self { cx, cz, sy }
+    }
+
+    #[must_use]
+    pub const fn column(self) -> ColumnCoord {
+        ColumnCoord {
+            cx: self.cx,
+            cz: self.cz,
+        }
+    }
+}
+
+/// Absolute cell position in volumetric world space.
+///
+/// This is foundation addressing vocabulary. The meaning of the stored value
+/// at that cell belongs to higher layers.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct WorldCellPos {
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+}
+
+impl WorldCellPos {
+    #[must_use]
+    pub const fn new(x: i32, y: i32, z: i32) -> Self {
+        Self { x, y, z }
+    }
+
+    #[must_use]
+    pub const fn tuple(self) -> (i32, i32, i32) {
+        (self.x, self.y, self.z)
+    }
+}
+
+impl From<(i32, i32, i32)> for WorldCellPos {
+    fn from(value: (i32, i32, i32)) -> Self {
+        Self {
+            x: value.0,
+            y: value.1,
+            z: value.2,
+        }
+    }
+}
+
+impl From<WorldCellPos> for (i32, i32, i32) {
+    fn from(value: WorldCellPos) -> Self {
+        (value.x, value.y, value.z)
+    }
+}

--- a/crates/freven_volumetric_sdk_types/src/lib.rs
+++ b/crates/freven_volumetric_sdk_types/src/lib.rs
@@ -1,80 +1,15 @@
 //! Stable volumetric foundation SDK contracts.
 //!
-//! This crate owns public volumetric topology and coordinate helpers.
-//! Storage encoding details remain engine-internal unless explicitly promoted later.
+//! This crate owns public volumetric topology, section/column addressing,
+//! and coordinate helpers.
+//!
+//! It does not own block gameplay semantics.
 
-/// Chunk section edge length in cells.
-///
-/// Protocol v1 currently uses 32^3 sections.
-pub const CHUNK_SECTION_DIM: usize = 32;
+mod addressing;
+mod topology;
 
-/// Total cells in a section.
-pub const CHUNK_SECTION_VOLUME: usize = CHUNK_SECTION_DIM * CHUNK_SECTION_DIM * CHUNK_SECTION_DIM;
-
-/// Canonical linearization order for a 32x32x32 section.
-///
-/// X-major order (x changes fastest), then Y, then Z:
-/// index = x + DIM * (y + DIM * z)
-#[inline]
-pub fn section_index(x: usize, y: usize, z: usize) -> usize {
-    debug_assert!(x < CHUNK_SECTION_DIM);
-    debug_assert!(y < CHUNK_SECTION_DIM);
-    debug_assert!(z < CHUNK_SECTION_DIM);
-    x + CHUNK_SECTION_DIM * (y + CHUNK_SECTION_DIM * z)
-}
-
-/// Floor division and modulo for negative coordinates.
-///
-/// Returns (q, r) such that:
-/// - x = q * d + r
-/// - r in [0, d)
-#[inline]
-pub fn div_mod_floor_i32(x: i32, d: i32) -> (i32, i32) {
-    debug_assert!(d > 0);
-    let mut q = x / d;
-    let mut r = x % d;
-    if r < 0 {
-        r += d;
-        q -= 1;
-    }
-    (q, r)
-}
-
-/// Convert world-space cell coordinate to (section coordinate, local coordinate in 0..DIM).
-#[inline]
-pub fn world_to_section_and_local(w: i32) -> (i32, usize) {
-    let (q, r) = div_mod_floor_i32(w, CHUNK_SECTION_DIM as i32);
-    debug_assert!(r >= 0);
-    (q, r as usize)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn section_index_matches_expected_layout() {
-        assert_eq!(section_index(0, 0, 0), 0);
-        assert_eq!(section_index(1, 0, 0), 1);
-        assert_eq!(section_index(0, 1, 0), CHUNK_SECTION_DIM);
-        assert_eq!(
-            section_index(0, 0, 1),
-            CHUNK_SECTION_DIM * CHUNK_SECTION_DIM
-        );
-    }
-
-    #[test]
-    fn div_mod_floor_handles_negative() {
-        let (q, r) = div_mod_floor_i32(-1, 32);
-        assert_eq!(q, -1);
-        assert_eq!(r, 31);
-
-        let (q, r) = div_mod_floor_i32(-32, 32);
-        assert_eq!(q, -1);
-        assert_eq!(r, 0);
-
-        let (q, r) = div_mod_floor_i32(-33, 32);
-        assert_eq!(q, -2);
-        assert_eq!(r, 31);
-    }
-}
+pub use addressing::{ColumnCoord, SectionCoord, SectionY, WorldCellPos};
+pub use topology::{
+    CHUNK_SECTION_DIM, CHUNK_SECTION_VOLUME, div_mod_floor_i32, section_index,
+    world_to_section_and_local,
+};

--- a/crates/freven_volumetric_sdk_types/src/topology.rs
+++ b/crates/freven_volumetric_sdk_types/src/topology.rs
@@ -1,0 +1,75 @@
+/// Chunk section edge length in cells.
+///
+/// Protocol v1 currently uses 32^3 sections.
+pub const CHUNK_SECTION_DIM: usize = 32;
+
+/// Total cells in a section.
+pub const CHUNK_SECTION_VOLUME: usize = CHUNK_SECTION_DIM * CHUNK_SECTION_DIM * CHUNK_SECTION_DIM;
+
+/// Canonical linearization order for one section.
+///
+/// X-major order (x changes fastest), then Y, then Z:
+/// index = x + DIM * (y + DIM * z)
+#[inline]
+pub fn section_index(x: usize, y: usize, z: usize) -> usize {
+    debug_assert!(x < CHUNK_SECTION_DIM);
+    debug_assert!(y < CHUNK_SECTION_DIM);
+    debug_assert!(z < CHUNK_SECTION_DIM);
+    x + CHUNK_SECTION_DIM * (y + CHUNK_SECTION_DIM * z)
+}
+
+/// Floor division and modulo for negative coordinates.
+///
+/// Returns `(q, r)` such that:
+/// - `x = q * d + r`
+/// - `r in [0, d)`
+#[inline]
+pub fn div_mod_floor_i32(x: i32, d: i32) -> (i32, i32) {
+    debug_assert!(d > 0);
+    let mut q = x / d;
+    let mut r = x % d;
+    if r < 0 {
+        r += d;
+        q -= 1;
+    }
+    (q, r)
+}
+
+/// Convert world-space cell coordinate to `(section coordinate, local coordinate in 0..DIM)`.
+#[inline]
+pub fn world_to_section_and_local(w: i32) -> (i32, usize) {
+    let (q, r) = div_mod_floor_i32(w, CHUNK_SECTION_DIM as i32);
+    debug_assert!(r >= 0);
+    (q, r as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn section_index_matches_expected_layout() {
+        assert_eq!(section_index(0, 0, 0), 0);
+        assert_eq!(section_index(1, 0, 0), 1);
+        assert_eq!(section_index(0, 1, 0), CHUNK_SECTION_DIM);
+        assert_eq!(
+            section_index(0, 0, 1),
+            CHUNK_SECTION_DIM * CHUNK_SECTION_DIM
+        );
+    }
+
+    #[test]
+    fn div_mod_floor_handles_negative() {
+        let (q, r) = div_mod_floor_i32(-1, 32);
+        assert_eq!(q, -1);
+        assert_eq!(r, 31);
+
+        let (q, r) = div_mod_floor_i32(-32, 32);
+        assert_eq!(q, -1);
+        assert_eq!(r, 0);
+
+        let (q, r) = div_mod_floor_i32(-33, 32);
+        assert_eq!(q, -2);
+        assert_eq!(r, 31);
+    }
+}

--- a/crates/freven_world_api/src/lib.rs
+++ b/crates/freven_world_api/src/lib.rs
@@ -5,6 +5,7 @@
 //! - expose deterministic registration surfaces (components/messages/worldgen/modnet/capabilities)
 //! - define stable hook contexts and registration errors
 //! - act as the builtin / compile-time facade over the canonical declaration model exposed by `freven_guest`
+//! - import volumetric topology/addressing truth from `freven_volumetric_sdk_types` instead of owning it here
 //!
 //! Extension guidance:
 //! - add new registries behind stable string keys

--- a/crates/freven_world_api/src/worldgen.rs
+++ b/crates/freven_world_api/src/worldgen.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use freven_block_sdk_types::BlockRuntimeId;
+use freven_volumetric_sdk_types::{ColumnCoord, SectionY, WorldCellPos};
 
 /// Contract for worldgen providers registered through SDK.
 pub trait WorldGenProvider: Send + Sync {
@@ -14,6 +15,9 @@ pub trait WorldGenProvider: Send + Sync {
 }
 
 /// Worldgen provider factory init parameters.
+///
+/// `block_ids` remains block-gameplay truth for now; volumetric topology and addressing
+/// come from `freven_volumetric_sdk_types`.
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct WorldGenInit {
@@ -41,28 +45,47 @@ impl WorldGenInit {
 /// Worldgen provider factory. One provider instance can be created per world/session.
 pub type WorldGenFactory = Arc<dyn Fn(WorldGenInit) -> Box<dyn WorldGenProvider> + Send + Sync>;
 
-/// Minimal worldgen request contract placeholder.
-#[derive(Debug, Default, Clone)]
+/// Minimal worldgen request contract for one requested column.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct WorldGenRequest {
     pub seed: u64,
-    pub cx: i32,
-    pub cz: i32,
+    pub column: ColumnCoord,
+}
+
+impl WorldGenRequest {
+    #[must_use]
+    pub const fn new(seed: u64, column: ColumnCoord) -> Self {
+        Self { seed, column }
+    }
+
+    #[must_use]
+    pub const fn cx(&self) -> i32 {
+        self.column.cx
+    }
+
+    #[must_use]
+    pub const fn cz(&self) -> i32 {
+        self.column.cz
+    }
 }
 
 /// World-owned terrain writes emitted by a worldgen provider.
+///
+/// Volumetric addressing is owned by `freven_volumetric_sdk_types`.
+/// Block ids remain block gameplay truth for now.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WorldTerrainWrite {
     FillSection {
-        sy: i8,
+        sy: SectionY,
         block_id: BlockRuntimeId,
     },
     FillBox {
-        min: (i32, i32, i32),
-        max: (i32, i32, i32),
+        min: WorldCellPos,
+        max: WorldCellPos,
         block_id: BlockRuntimeId,
     },
     SetBlock {
-        pos: (i32, i32, i32),
+        pos: WorldCellPos,
         block_id: BlockRuntimeId,
     },
 }

--- a/crates/freven_world_guest/Cargo.toml
+++ b/crates/freven_world_guest/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+freven_volumetric_sdk_types.workspace = true
 freven_guest.workspace = true
 freven_sdk_types.workspace = true
 freven_world_sdk_types.workspace = true

--- a/crates/freven_world_guest/src/lib.rs
+++ b/crates/freven_world_guest/src/lib.rs
@@ -9,11 +9,11 @@ extern crate alloc;
 use alloc::collections::BTreeMap;
 use alloc::{string::String, vec::Vec};
 use freven_block_sdk_types::{BlockDescriptor, BlockRuntimeId};
-use freven_volumetric_sdk_types::{ColumnCoord, SectionY, WorldCellPos};
 use freven_guest::{
     CapabilityDeclaration, ChannelDeclaration, ComponentDeclaration, LifecycleHooks, LogPayload,
     MessageDeclaration, MessageHooks, RuntimeSessionInfo,
 };
+use freven_volumetric_sdk_types::{ColumnCoord, SectionY, WorldCellPos};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/freven_world_guest/src/lib.rs
+++ b/crates/freven_world_guest/src/lib.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 use alloc::collections::BTreeMap;
 use alloc::{string::String, vec::Vec};
 use freven_block_sdk_types::{BlockDescriptor, BlockRuntimeId};
+use freven_volumetric_sdk_types::{ColumnCoord, SectionY, WorldCellPos};
 use freven_guest::{
     CapabilityDeclaration, ChannelDeclaration, ComponentDeclaration, LifecycleHooks, LogPayload,
     MessageDeclaration, MessageHooks, RuntimeSessionInfo,
@@ -116,8 +117,24 @@ impl WorldGenInit {
 #[serde(default)]
 pub struct WorldGenRequest {
     pub seed: u64,
-    pub cx: i32,
-    pub cz: i32,
+    pub column: ColumnCoord,
+}
+
+impl WorldGenRequest {
+    #[must_use]
+    pub const fn new(seed: u64, column: ColumnCoord) -> Self {
+        Self { seed, column }
+    }
+
+    #[must_use]
+    pub const fn cx(&self) -> i32 {
+        self.column.cx
+    }
+
+    #[must_use]
+    pub const fn cz(&self) -> i32 {
+        self.column.cz
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -129,16 +146,16 @@ pub struct WorldGenOutput {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum WorldTerrainWrite {
     FillSection {
-        sy: i8,
+        sy: SectionY,
         block_id: BlockRuntimeId,
     },
     FillBox {
-        min: (i32, i32, i32),
-        max: (i32, i32, i32),
+        min: WorldCellPos,
+        max: WorldCellPos,
         block_id: BlockRuntimeId,
     },
     SetBlock {
-        pos: (i32, i32, i32),
+        pos: WorldCellPos,
         block_id: BlockRuntimeId,
     },
 }

--- a/crates/freven_world_guest_sdk/src/lib.rs
+++ b/crates/freven_world_guest_sdk/src/lib.rs
@@ -3833,7 +3833,7 @@ mod tests {
         WorldGenCallResult {
             output: WorldGenOutput {
                 writes: vec![WorldTerrainWrite::FillSection {
-                    sy: 0,
+                    sy: 0.into(),
                     block_id: BlockRuntimeId(7),
                 }],
             },
@@ -4278,7 +4278,7 @@ mod tests {
         assert_eq!(worldgen.output.writes.len(), 1);
         match &worldgen.output.writes[0] {
             WorldTerrainWrite::FillSection { sy, block_id } => {
-                assert_eq!(*sy, 0);
+                assert_eq!(*sy, 0.into());
                 assert_eq!(*block_id, BlockRuntimeId(7));
             }
             write => panic!("unexpected worldgen write: {write:?}"),


### PR DESCRIPTION
## Summary
Extend the public volumetric foundation in `freven-sdk` with explicit addressing value types and migrate worldgen-facing contracts to use that vocabulary.

This PR:
- adds stable volumetric addressing types to `freven_volumetric_sdk_types`:
  - `ColumnCoord`
  - `SectionY`
  - `SectionCoord`
  - `WorldCellPos`
- splits topology helpers into a dedicated `topology` module and keeps them re-exported from the crate root;
- enables serde support for `freven_volumetric_sdk_types` so those addressing types can participate in guest/runtime serialization;
- updates `freven_world_api::WorldGenRequest` to carry a `ColumnCoord` instead of raw `cx` / `cz` fields;
- updates `WorldTerrainWrite` contracts in both `freven_world_api` and `freven_world_guest` to use `SectionY` and `WorldCellPos` instead of primitive integers and tuples;
- wires the new volumetric SDK types into `freven_world_guest` and adjusts guest-sdk tests accordingly.

## Why
The `mod-architecture-stage-4.4-volumetric-foundation` work needs a clearer public vocabulary for volumetric addressing. Raw tuples and loose integer fields are workable for MVP code, but they do not express ownership or intent very well and make it harder to separate volumetric topology truth from higher-level gameplay semantics.

By introducing dedicated addressing value types in `freven_volumetric_sdk_types`, the SDK gets a stronger foundation for:
- column-oriented worldgen requests;
- section-addressed volumetric operations;
- world-cell write coordinates;
- future runtime and protocol evolution built on stable public types instead of ad hoc primitive shapes.

This keeps volumetric topology/addressing in the foundation crate where it belongs, while `freven_world_api` stays a higher-level world-facing contract layer that imports that truth instead of redefining it.

## Validation
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo test --workspace --all-features

## freven-sdk dependency
- Does this PR change the pinned `freven-sdk` tag?
  - [x] No
  - [ ] Yes (which tag and why?)

## Notes for reviewers
The main thing to review is the contract shift from primitives to explicit volumetric addressing types:
- `WorldGenRequest` should now model the requested column explicitly;
- worldgen writes should carry typed volumetric coordinates instead of raw tuples;
- `freven_volumetric_sdk_types` should remain purely foundational and free of block-gameplay semantics.