### PR TITLE
Introduce avatar-owned SDK surfaces for control, controller, and presentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "freven_avatar_api"
+version = "0.1.0"
+dependencies = [
+ "freven_avatar_sdk_types",
+ "freven_block_api",
+ "freven_mod_api",
+ "freven_world_api",
+]
+
+[[package]]
+name = "freven_avatar_sdk_types"
+version = "0.1.0"
+dependencies = [
+ "freven_world_api",
+ "freven_world_guest",
+]
+
+[[package]]
 name = "freven_block_api"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/freven_avatar_sdk_types",
+    "crates/freven_avatar_api",
     "crates/freven_mod_api",
     "crates/freven_guest",
     "crates/freven_guest_sdk",
@@ -25,10 +27,13 @@ documentation = "https://github.com/frevenengine/freven-sdk/tree/main/docs"
 publish = false
 
 [workspace.dependencies]
+freven_avatar_sdk_types = { path = "crates/freven_avatar_sdk_types", version = "0.1.0" }
+freven_avatar_api = { path = "crates/freven_avatar_api", version = "0.1.0" }
 freven_mod_api = { path = "crates/freven_mod_api", version = "0.1.0" }
 freven_guest = { path = "crates/freven_guest", version = "0.1.0" }
 freven_guest_sdk = { path = "crates/freven_guest_sdk", version = "0.1.0" }
 freven_sdk_types = { path = "crates/freven_sdk_types", version = "0.1.0" }
+freven_world_api = { path = "crates/freven_world_api", version = "0.1.0" }
 freven_world_guest = { path = "crates/freven_world_guest", version = "0.1.0" }
 freven_world_sdk_types = { path = "crates/freven_world_sdk_types", version = "0.1.0" }
 freven_volumetric_sdk_types = { path = "crates/freven_volumetric_sdk_types", version = "0.1.0" }

--- a/crates/freven_avatar_api/Cargo.toml
+++ b/crates/freven_avatar_api/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "freven_avatar_api"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "Explicit avatar-owned public SDK facade for Freven."
+publish = false
+
+[dependencies]
+freven_block_api.workspace = true
+freven_avatar_sdk_types.workspace = true
+freven_mod_api.workspace = true
+freven_world_api.workspace = true

--- a/crates/freven_avatar_api/src/control.rs
+++ b/crates/freven_avatar_api/src/control.rs
@@ -1,0 +1,53 @@
+pub use freven_avatar_sdk_types::control::*;
+
+use freven_avatar_sdk_types::control::{
+    ClientControlProvider as AvatarClientControlProvider,
+    ClientControlProviderFactory as AvatarClientControlProviderFactory,
+    ClientControlProviderInit as AvatarClientControlProviderInit,
+};
+use freven_world_api::{ModContext, ModRegistrationError};
+use std::sync::Arc;
+
+/// Numeric id for registered client control providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ClientControlProviderId(pub u32);
+
+pub trait AvatarControlRegistrationExt {
+    fn register_client_control_provider(
+        &mut self,
+        key: &str,
+        factory: impl Fn(AvatarClientControlProviderInit) -> Box<dyn AvatarClientControlProvider>
+        + Send
+        + Sync
+        + 'static,
+    ) -> Result<ClientControlProviderId, ModRegistrationError>;
+
+    #[doc(hidden)]
+    fn __register_client_control_provider_factory(
+        &mut self,
+        key: &str,
+        factory: AvatarClientControlProviderFactory,
+    ) -> Result<ClientControlProviderId, ModRegistrationError>;
+}
+
+impl AvatarControlRegistrationExt for ModContext<'_> {
+    fn register_client_control_provider(
+        &mut self,
+        key: &str,
+        factory: impl Fn(AvatarClientControlProviderInit) -> Box<dyn AvatarClientControlProvider>
+        + Send
+        + Sync
+        + 'static,
+    ) -> Result<ClientControlProviderId, ModRegistrationError> {
+        self.__register_client_control_provider_factory(key, Arc::new(factory))
+    }
+
+    fn __register_client_control_provider_factory(
+        &mut self,
+        key: &str,
+        factory: AvatarClientControlProviderFactory,
+    ) -> Result<ClientControlProviderId, ModRegistrationError> {
+        self.__register_avatar_client_control_provider(key, Box::new(factory))
+            .map(ClientControlProviderId)
+    }
+}

--- a/crates/freven_avatar_api/src/controller.rs
+++ b/crates/freven_avatar_api/src/controller.rs
@@ -1,0 +1,53 @@
+pub use freven_avatar_sdk_types::controller::*;
+
+use freven_avatar_sdk_types::controller::{
+    CharacterController as AvatarCharacterController,
+    CharacterControllerFactory as AvatarCharacterControllerFactory,
+    CharacterControllerInit as AvatarCharacterControllerInit,
+};
+use freven_world_api::{ModContext, ModRegistrationError};
+use std::sync::Arc;
+
+/// Numeric id for registered avatar controllers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CharacterControllerId(pub u32);
+
+pub trait AvatarControllerRegistrationExt {
+    fn register_character_controller(
+        &mut self,
+        key: &str,
+        factory: impl Fn(AvatarCharacterControllerInit) -> Box<dyn AvatarCharacterController>
+        + Send
+        + Sync
+        + 'static,
+    ) -> Result<CharacterControllerId, ModRegistrationError>;
+
+    #[doc(hidden)]
+    fn __register_character_controller_factory(
+        &mut self,
+        key: &str,
+        factory: AvatarCharacterControllerFactory,
+    ) -> Result<CharacterControllerId, ModRegistrationError>;
+}
+
+impl AvatarControllerRegistrationExt for ModContext<'_> {
+    fn register_character_controller(
+        &mut self,
+        key: &str,
+        factory: impl Fn(AvatarCharacterControllerInit) -> Box<dyn AvatarCharacterController>
+        + Send
+        + Sync
+        + 'static,
+    ) -> Result<CharacterControllerId, ModRegistrationError> {
+        self.__register_character_controller_factory(key, Arc::new(factory))
+    }
+
+    fn __register_character_controller_factory(
+        &mut self,
+        key: &str,
+        factory: AvatarCharacterControllerFactory,
+    ) -> Result<CharacterControllerId, ModRegistrationError> {
+        self.__register_avatar_character_controller(key, Box::new(factory))
+            .map(CharacterControllerId)
+    }
+}

--- a/crates/freven_avatar_api/src/identity.rs
+++ b/crates/freven_avatar_api/src/identity.rs
@@ -1,0 +1,1 @@
+pub use freven_avatar_sdk_types::identity::*;

--- a/crates/freven_avatar_api/src/lib.rs
+++ b/crates/freven_avatar_api/src/lib.rs
@@ -1,0 +1,17 @@
+//! Explicit avatar-owned public SDK facade.
+//!
+//! This crate is the public owner for avatar identity, control, controller,
+//! and presentation contracts. Registration-facing helpers live here so the
+//! owner layer is visible at import sites.
+
+pub mod control;
+pub mod controller;
+pub mod identity;
+pub mod lifecycle;
+pub mod presentation;
+
+pub use control::*;
+pub use controller::*;
+pub use identity::*;
+pub use lifecycle::*;
+pub use presentation::*;

--- a/crates/freven_avatar_api/src/lifecycle.rs
+++ b/crates/freven_avatar_api/src/lifecycle.rs
@@ -1,0 +1,89 @@
+use std::time::Duration;
+
+use freven_avatar_sdk_types::{control::ClientInputProvider, presentation::ClientPlayerProvider};
+use freven_block_api::ClientCameraHitProvider;
+use freven_mod_api::{LogLevel, emit_log};
+use freven_world_api::{ClientInteractionProvider, ModContext, Services};
+
+/// Lifecycle callback executed once when the client side starts.
+pub type StartClientHook = for<'a> fn(&mut ClientApi<'a>);
+
+/// Lifecycle callback executed on each client tick.
+pub type TickClientHook = for<'a> fn(&mut ClientTickApi<'a>);
+
+/// Avatar-facing client lifecycle API.
+pub struct ClientApi<'a> {
+    pub services: &'a mut dyn Services,
+    pub input: &'a mut dyn ClientInputProvider,
+    pub camera: &'a mut dyn ClientCameraHitProvider,
+    pub interaction: &'a mut dyn ClientInteractionProvider,
+    pub players: &'a mut dyn ClientPlayerProvider,
+}
+
+impl<'a> ClientApi<'a> {
+    #[must_use]
+    pub fn new(
+        services: &'a mut dyn Services,
+        input: &'a mut dyn ClientInputProvider,
+        camera: &'a mut dyn ClientCameraHitProvider,
+        interaction: &'a mut dyn ClientInteractionProvider,
+        players: &'a mut dyn ClientPlayerProvider,
+    ) -> Self {
+        Self {
+            services,
+            input,
+            camera,
+            interaction,
+            players,
+        }
+    }
+
+    #[must_use]
+    pub fn reborrow(&mut self) -> ClientApi<'_> {
+        ClientApi {
+            services: self.services,
+            input: self.input,
+            camera: self.camera,
+            interaction: self.interaction,
+            players: self.players,
+        }
+    }
+
+    pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
+        let _ = &self.services;
+        emit_log(level, message);
+    }
+}
+
+/// Avatar-facing client tick lifecycle API.
+pub struct ClientTickApi<'a> {
+    pub tick: u64,
+    pub dt: Duration,
+    pub client: ClientApi<'a>,
+}
+
+impl<'a> ClientTickApi<'a> {
+    #[must_use]
+    pub fn new(tick: u64, dt: Duration, client: ClientApi<'a>) -> Self {
+        Self { tick, dt, client }
+    }
+
+    pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
+        self.client.log(level, message);
+    }
+}
+
+pub trait AvatarLifecycleRegistrationExt {
+    fn on_start_client(&mut self, hook: StartClientHook);
+    fn on_tick_client(&mut self, hook: TickClientHook);
+}
+
+impl AvatarLifecycleRegistrationExt for ModContext<'_> {
+    fn on_start_client(&mut self, hook: StartClientHook) {
+        self.__on_avatar_start_client(Box::new(hook));
+    }
+
+    fn on_tick_client(&mut self, hook: TickClientHook) {
+        self.__on_avatar_tick_client(Box::new(hook));
+    }
+}

--- a/crates/freven_avatar_api/src/presentation.rs
+++ b/crates/freven_avatar_api/src/presentation.rs
@@ -1,0 +1,1 @@
+pub use freven_avatar_sdk_types::presentation::*;

--- a/crates/freven_avatar_sdk_types/Cargo.toml
+++ b/crates/freven_avatar_sdk_types/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "freven_avatar_sdk_types"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "Explicit avatar-owned SDK contracts for Freven identity, control, controller, and presentation surfaces."
+publish = false
+
+[dependencies]
+freven_world_api.workspace = true
+freven_world_guest.workspace = true

--- a/crates/freven_avatar_sdk_types/src/control.rs
+++ b/crates/freven_avatar_sdk_types/src/control.rs
@@ -1,0 +1,94 @@
+use std::sync::Arc;
+
+pub use freven_world_guest::{
+    ClientKeyCode as GuestClientKeyCode, ClientMouseButton as GuestClientMouseButton,
+};
+
+/// Client control provider output for one input sample.
+///
+/// Notes:
+/// - The engine owns input sequencing as part of the prediction/network timeline.
+/// - Control providers must NOT generate or persist input sequence numbers.
+#[derive(Debug, Clone)]
+pub struct ClientControlOutput {
+    pub input: Arc<[u8]>,
+    pub view_yaw_deg: f32,
+    pub view_pitch_deg: f32,
+}
+
+/// Timeline metadata associated with one controller input sample.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct InputTimeline {
+    pub input_seq: u32,
+    pub sim_tick: u64,
+}
+
+/// Init params for client control provider factories.
+///
+/// Reserved for future evolution.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct ClientControlProviderInit {}
+
+/// Mouse buttons for client input polling/consumption.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ClientMouseButton {
+    Left,
+    Right,
+    Middle,
+}
+
+/// Keyboard keys for client input polling/consumption.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ClientKeyCode {
+    KeyW,
+    KeyA,
+    KeyS,
+    KeyD,
+    KeyE,
+    KeyQ,
+    Space,
+    Shift,
+    Ctrl,
+    Escape,
+}
+
+/// Contract for gameplay control providers owned by mods.
+///
+/// This is a pure mapping: device state -> raw input.
+/// Providers may keep internal filters, but must not own network sequencing.
+pub trait ClientControlProvider: Send + Sync {
+    fn sample(&mut self, device: &mut dyn ClientControlDeviceState) -> ClientControlOutput;
+
+    /// Optional hook to clear internal filters on hard resets.
+    fn reset(&mut self) {}
+}
+
+/// Factory for client control providers.
+pub type ClientControlProviderFactory =
+    Arc<dyn Fn(ClientControlProviderInit) -> Box<dyn ClientControlProvider> + Send + Sync>;
+
+/// Engine-provided client input surface.
+pub trait ClientInputProvider {
+    fn mouse_button_down(&self, button: ClientMouseButton) -> bool;
+    fn mouse_button_just_pressed(&self, button: ClientMouseButton) -> bool;
+    fn key_down(&self, key: ClientKeyCode) -> bool;
+    fn key_just_pressed(&self, key: ClientKeyCode) -> bool;
+    fn bind_mouse_button(&mut self, button: ClientMouseButton, owner: &str) -> bool;
+    fn bind_key(&mut self, key: ClientKeyCode, owner: &str) -> bool;
+    fn consume_mouse_button_press(&mut self, button: ClientMouseButton, owner: &str) -> bool;
+    fn consume_key_press(&mut self, key: ClientKeyCode, owner: &str) -> bool;
+}
+
+/// Engine-provided raw device input state for client control providers.
+pub trait ClientControlDeviceState {
+    fn bind_mouse_button(&mut self, button: ClientMouseButton, owner: &str) -> bool;
+    fn bind_key(&mut self, key: ClientKeyCode, owner: &str) -> bool;
+    fn mouse_button_down(&self, button: ClientMouseButton, owner: &str) -> bool;
+    fn key_down(&self, key: ClientKeyCode, owner: &str) -> bool;
+    fn mouse_delta(&self) -> (f32, f32);
+    fn cursor_locked(&self) -> bool;
+    fn view_angles_deg(&self) -> (f32, f32);
+}

--- a/crates/freven_avatar_sdk_types/src/controller.rs
+++ b/crates/freven_avatar_sdk_types/src/controller.rs
@@ -1,50 +1,13 @@
-use crate::ClientControlDeviceState;
+use crate::control::InputTimeline;
 use std::{sync::Arc, time::Duration};
 
-/// Client control provider output for one input sample.
-///
-/// Notes:
-/// - The engine owns input sequencing (`NetSeq`) as part of the prediction/network timeline.
-/// - Control providers must NOT generate or persist input sequence numbers.
-#[derive(Debug, Clone)]
-pub struct ClientControlOutput {
-    pub input: Arc<[u8]>,
-    pub view_yaw_deg: f32,
-    pub view_pitch_deg: f32,
-}
-
-/// Timeline metadata associated with one controller input sample.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct InputTimeline {
-    pub input_seq: u32,
-    pub sim_tick: u64,
-}
-
-/// Opaque controller input consumed by character controllers.
+/// Opaque controller input consumed by avatar controllers.
 #[derive(Debug, Clone)]
 pub struct CharacterControllerInput {
     pub input: Arc<[u8]>,
     pub view_yaw_deg: f32,
     pub view_pitch_deg: f32,
     pub timeline: InputTimeline,
-}
-
-/// Init params for client control provider factories.
-///
-/// Reserved for future evolution (e.g., default sensitivity presets).
-#[derive(Debug, Clone, Copy, Default)]
-#[non_exhaustive]
-pub struct ClientControlProviderInit {}
-
-/// Contract for gameplay control providers owned by mods.
-///
-/// This is a pure mapping: device state -> raw input.
-/// Providers may keep internal filters (e.g. smoothing), but must not own network sequencing.
-pub trait ClientControlProvider: Send + Sync {
-    fn sample(&mut self, device: &mut dyn ClientControlDeviceState) -> ClientControlOutput;
-
-    /// Optional hook to clear internal filters on hard resets (world barrier / reconnect).
-    fn reset(&mut self) {}
 }
 
 /// Character shape used for collision queries.
@@ -64,15 +27,6 @@ pub struct CharacterConfig {
     pub accel_air: f32,
     pub gravity: f32,
     pub jump_impulse: f32,
-    /// Maximum step-up height in meters.
-    ///
-    /// This is **controller-defined** behavior: the engine does not apply stepping by itself.
-    /// Controllers may use this value to implement classic "step-up" (walk up small ledges)
-    /// using additional collision probes/resolution.
-    ///
-    /// MVP note:
-    /// - `freven_vanilla_essentials` humanoid controller currently does not implement step-up
-    ///   and keeps `step_height = 0.0`.
     pub step_height: f32,
     pub skin_width: f32,
 }
@@ -88,7 +42,6 @@ pub struct CharacterState {
 /// Wire millimeter scale used for position/velocity quantization.
 pub const WIRE_MM_SCALE: f32 = 1000.0;
 
-/// Quantize meters to wire millimeters using round-to-nearest.
 #[inline]
 #[must_use]
 pub fn quantize_mm_i32(value_m: f32) -> i32 {
@@ -96,21 +49,18 @@ pub fn quantize_mm_i32(value_m: f32) -> i32 {
     mm.clamp(i32::MIN as f32, i32::MAX as f32) as i32
 }
 
-/// Dequantize wire millimeters back to meters.
 #[inline]
 #[must_use]
 pub fn dequantize_mm_i32(value_mm: i32) -> f32 {
     value_mm as f32 / WIRE_MM_SCALE
 }
 
-/// Round-trip meters through wire millimeter precision.
 #[inline]
 #[must_use]
 pub fn quantize_m_to_wire_mm(value_m: f32) -> f32 {
     dequantize_mm_i32(quantize_mm_i32(value_m))
 }
 
-/// Quantize character runtime state to wire millimeter precision.
 #[inline]
 pub fn quantize_character_state_mm(state: &mut CharacterState) {
     state.pos[0] = quantize_m_to_wire_mm(state.pos[0]);
@@ -142,20 +92,16 @@ impl Default for SweepHit {
 /// Terrain solidity sample for kinematic AABB movement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SolidSample {
-    /// True when sampled voxel is solid.
     pub solid: bool,
-    /// True when voxel state is known/loaded.
     pub known: bool,
 }
 
 impl SolidSample {
-    /// Known sample constructor.
     #[must_use]
     pub const fn known(solid: bool) -> Self {
         Self { solid, known: true }
     }
 
-    /// Unknown sample constructor.
     #[must_use]
     pub const fn unknown() -> Self {
         Self {
@@ -168,13 +114,9 @@ impl SolidSample {
 /// Configuration for deterministic kinematic terrain movement.
 #[derive(Debug, Clone, Copy)]
 pub struct KinematicMoveConfig {
-    /// Desired wall/floor gap in meters.
     pub skin_width: f32,
-    /// Tiny numerical epsilon used only for overlap/range stability.
     pub contact_epsilon: f32,
-    /// Upper bound on internal substeps used for large motions.
     pub max_substeps: u8,
-    /// Maximum absolute axis motion per internal substep.
     pub max_motion_per_step: f32,
 }
 
@@ -188,7 +130,6 @@ impl KinematicMoveConfig {
     const MOTION_STEP_MIN: f32 = 1.0e-3;
     const MOTION_STEP_MAX: f32 = 10.0;
 
-    /// Return a clamped config suitable for simulation/runtime use.
     #[must_use]
     pub fn validated(mut self) -> Self {
         self.skin_width = self.skin_width.abs().clamp(Self::SKIN_MIN, Self::SKIN_MAX);
@@ -246,7 +187,7 @@ impl Default for KinematicMoveResult {
     }
 }
 
-/// Engine-side collision queries consumed by character controllers.
+/// Engine-side collision queries consumed by avatar controllers.
 pub trait CharacterPhysics {
     fn is_solid_world_collision(&mut self, wx: i32, wy: i32, wz: i32) -> bool;
     fn sweep_aabb(&mut self, half_extents: [f32; 3], from: [f32; 3], to: [f32; 3]) -> SweepHit;
@@ -279,7 +220,3 @@ pub struct CharacterControllerInit {}
 /// Character controller factory.
 pub type CharacterControllerFactory =
     Arc<dyn Fn(CharacterControllerInit) -> Box<dyn CharacterController> + Send + Sync>;
-
-/// Client control provider factory.
-pub type ClientControlProviderFactory =
-    Arc<dyn Fn(ClientControlProviderInit) -> Box<dyn ClientControlProvider> + Send + Sync>;

--- a/crates/freven_avatar_sdk_types/src/identity.rs
+++ b/crates/freven_avatar_sdk_types/src/identity.rs
@@ -1,0 +1,2 @@
+/// Stable avatar/player identity used by avatar-owned public contracts.
+pub type PlayerId = u64;

--- a/crates/freven_avatar_sdk_types/src/lib.rs
+++ b/crates/freven_avatar_sdk_types/src/lib.rs
@@ -1,0 +1,17 @@
+//! Explicit avatar-owned SDK contracts.
+//!
+//! This crate owns public contracts that are not world-neutral:
+//! - avatar identity
+//! - client control input and control-provider contracts
+//! - controller-facing movement contracts
+//! - client presentation views over avatar/player state
+
+pub mod control;
+pub mod controller;
+pub mod identity;
+pub mod presentation;
+
+pub use control::*;
+pub use controller::*;
+pub use identity::*;
+pub use presentation::*;

--- a/crates/freven_avatar_sdk_types/src/presentation.rs
+++ b/crates/freven_avatar_sdk_types/src/presentation.rs
@@ -1,0 +1,20 @@
+use crate::identity::PlayerId;
+use freven_world_api::ComponentId;
+
+pub use freven_world_guest::ClientPlayerView as GuestClientPlayerView;
+
+/// Lightweight avatar view for client-side presentation mods.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ClientPlayerView {
+    pub player_id: PlayerId,
+    pub world_pos_m: (f32, f32, f32),
+    pub is_local: bool,
+}
+
+/// Engine-provided avatar presentation query surface.
+pub trait ClientPlayerProvider {
+    fn list_players(&self, out: &mut Vec<ClientPlayerView>);
+    fn display_name_for(&self, player_id: PlayerId) -> Option<String>;
+    fn component_bytes_for(&self, player_id: PlayerId, component_id: ComponentId) -> Option<&[u8]>;
+    fn world_to_screen(&self, world_pos_m: (f32, f32, f32)) -> Option<(f32, f32)>;
+}

--- a/crates/freven_world_api/src/client.rs
+++ b/crates/freven_world_api/src/client.rs
@@ -1,42 +1,7 @@
+use freven_block_api::{ClientActionEdit, ClientPredictedEdit};
 use std::sync::Arc;
 
-use freven_block_api::{ClientActionEdit, ClientPredictedEdit};
-
 use crate::action::ActionKindId;
-
-pub use freven_world_guest::ClientPlayerView as GuestClientPlayerView;
-
-/// Mouse buttons for client input polling/consumption.
-///
-/// This enum is a convenience surface for common desktop bindings.
-/// The primary cross-layer gameplay contract remains opaque input bytes
-/// (`ClientControlOutput::input` / `CharacterControllerInput::input`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[non_exhaustive]
-pub enum ClientMouseButton {
-    Left,
-    Right,
-    Middle,
-}
-
-/// Keyboard keys for client input polling/consumption.
-///
-/// This enum is a convenience surface for common desktop bindings.
-/// Prefer mod-defined opaque input payloads as the stable gameplay contract.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[non_exhaustive]
-pub enum ClientKeyCode {
-    KeyW,
-    KeyA,
-    KeyS,
-    KeyD,
-    KeyE,
-    KeyQ,
-    Space,
-    Shift,
-    Ctrl,
-    Escape,
-}
 
 /// Client-side action request submitted by gameplay/mods.
 ///
@@ -121,62 +86,6 @@ pub struct ClientActionResultEvent {
 
     /// Authoritative world edits produced by the server for this action.
     pub edits: Vec<ClientActionEdit>,
-}
-
-/// Lightweight player view for client-side presentation mods.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ClientPlayerView {
-    pub player_id: u64,
-    pub world_pos_m: (f32, f32, f32),
-    pub is_local: bool,
-}
-
-/// Engine-provided client input surface.
-pub trait ClientInputProvider {
-    /// Raw device hold state for the current engine frame.
-    fn mouse_button_down(&self, button: ClientMouseButton) -> bool;
-
-    /// Raw render/update-frame press edge.
-    ///
-    /// This is frame-scoped engine input state, not a gameplay-tick latch. Gameplay systems that
-    /// can tick at a different cadence must not rely on this for durable action submission.
-    fn mouse_button_just_pressed(&self, button: ClientMouseButton) -> bool;
-
-    /// Raw device hold state for the current engine frame.
-    fn key_down(&self, key: ClientKeyCode) -> bool;
-
-    /// Raw render/update-frame press edge.
-    ///
-    /// This is frame-scoped engine input state, not a gameplay-tick latch. Gameplay systems that
-    /// can tick at a different cadence must not rely on this for durable action submission.
-    fn key_just_pressed(&self, key: ClientKeyCode) -> bool;
-    fn bind_mouse_button(&mut self, button: ClientMouseButton, owner: &str) -> bool;
-    fn bind_key(&mut self, key: ClientKeyCode, owner: &str) -> bool;
-
-    /// Consume one buffered mouse press for a gameplay-tick owner.
-    ///
-    /// Contract:
-    /// - each successful consume corresponds to one raw press edge captured by the engine
-    /// - presses are buffered across render frames until consumed or a gameplay reset clears them
-    /// - multiple render-frame presses before the next gameplay tick must be delivered one-by-one
-    /// - multiple gameplay ticks in one render frame must not re-consume the same raw edge
-    fn consume_mouse_button_press(&mut self, button: ClientMouseButton, owner: &str) -> bool;
-
-    /// Consume one buffered key press for a gameplay-tick owner.
-    ///
-    /// Semantics match `consume_mouse_button_press`.
-    fn consume_key_press(&mut self, key: ClientKeyCode, owner: &str) -> bool;
-}
-
-/// Engine-provided raw device input state for client control providers.
-pub trait ClientControlDeviceState {
-    fn bind_mouse_button(&mut self, button: ClientMouseButton, owner: &str) -> bool;
-    fn bind_key(&mut self, key: ClientKeyCode, owner: &str) -> bool;
-    fn mouse_button_down(&self, button: ClientMouseButton, owner: &str) -> bool;
-    fn key_down(&self, key: ClientKeyCode, owner: &str) -> bool;
-    fn mouse_delta(&self) -> (f32, f32);
-    fn cursor_locked(&self) -> bool;
-    fn view_angles_deg(&self) -> (f32, f32);
 }
 
 /// Engine-provided interaction request/result surface.

--- a/crates/freven_world_api/src/lib.rs
+++ b/crates/freven_world_api/src/lib.rs
@@ -7,6 +7,7 @@
 //! - act as the builtin / compile-time facade over the canonical declaration model exposed by `freven_guest`
 //! - import volumetric topology/addressing truth from `freven_volumetric_sdk_types` instead of owning it here
 //! - import standard block/profile vocabulary from `freven_block_sdk_types` instead of owning it here
+//! - remain free of avatar/controller/presentation public ownership, which lives in the avatar-owned family
 //!
 //! Current state note:
 //! - some world-stack consumer contracts in this crate still reference block/profile vocabulary
@@ -20,7 +21,6 @@
 //! - do not redefine or re-export standard block/profile vocabulary from this crate
 
 pub mod action;
-pub mod character;
 pub mod client;
 pub mod lifecycle;
 pub mod messages;
@@ -30,7 +30,6 @@ pub mod services;
 pub mod worldgen;
 
 pub use action::*;
-pub use character::*;
 pub use client::*;
 pub use lifecycle::*;
 pub use messages::*;

--- a/crates/freven_world_api/src/lifecycle.rs
+++ b/crates/freven_world_api/src/lifecycle.rs
@@ -1,26 +1,15 @@
 use std::time::Duration;
 
-use freven_mod_api::{LogLevel, emit_log};
-
-use freven_block_api::ClientCameraHitProvider;
-
 use crate::{
-    client::{ClientInputProvider, ClientInteractionProvider},
     messages::{
-        ClientInboundMessage, ClientMessageSender, ClientPlayerProvider, ServerInboundMessage,
-        ServerMessageSender,
+        ClientInboundMessage, ClientMessageSender, ServerInboundMessage, ServerMessageSender,
     },
     services::Services,
 };
-
-/// Lifecycle callback executed once when the client side starts.
-pub type StartClientHook = for<'a> fn(&mut ClientApi<'a>);
+use freven_mod_api::{LogLevel, emit_log};
 
 /// Lifecycle callback executed once when the server side starts.
 pub type StartServerHook = for<'a> fn(&mut ServerApi<'a>);
-
-/// Lifecycle callback executed on each client tick.
-pub type TickClientHook = for<'a> fn(&mut ClientTickApi<'a>);
 
 /// Lifecycle callback executed on each server tick.
 pub type TickServerHook = for<'a> fn(&mut ServerTickApi<'a>);
@@ -40,50 +29,6 @@ impl<'a> ServerApi<'a> {
     #[must_use]
     pub fn new(services: &'a mut dyn Services) -> Self {
         Self { services }
-    }
-
-    pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
-        let _ = &self.services;
-        emit_log(level, message);
-    }
-}
-
-/// Client-side lifecycle API.
-pub struct ClientApi<'a> {
-    pub services: &'a mut dyn Services,
-    pub input: &'a mut dyn ClientInputProvider,
-    pub camera: &'a mut dyn ClientCameraHitProvider,
-    pub interaction: &'a mut dyn ClientInteractionProvider,
-    pub players: &'a mut dyn ClientPlayerProvider,
-}
-
-impl<'a> ClientApi<'a> {
-    #[must_use]
-    pub fn new(
-        services: &'a mut dyn Services,
-        input: &'a mut dyn ClientInputProvider,
-        camera: &'a mut dyn ClientCameraHitProvider,
-        interaction: &'a mut dyn ClientInteractionProvider,
-        players: &'a mut dyn ClientPlayerProvider,
-    ) -> Self {
-        Self {
-            services,
-            input,
-            camera,
-            interaction,
-            players,
-        }
-    }
-
-    #[must_use]
-    pub fn reborrow(&mut self) -> ClientApi<'_> {
-        ClientApi {
-            services: self.services,
-            input: self.input,
-            camera: self.camera,
-            interaction: self.interaction,
-            players: self.players,
-        }
     }
 
     pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
@@ -155,24 +100,6 @@ impl<'a> ServerMessagesApi<'a> {
     pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
         let _ = &self.services;
         emit_log(level, message);
-    }
-}
-
-/// Client-side lifecycle tick context.
-pub struct ClientTickApi<'a> {
-    pub tick: u64,
-    pub dt: Duration,
-    pub client: ClientApi<'a>,
-}
-
-impl<'a> ClientTickApi<'a> {
-    #[must_use]
-    pub fn new(tick: u64, dt: Duration, client: ClientApi<'a>) -> Self {
-        Self { tick, dt, client }
-    }
-
-    pub fn log(&mut self, level: LogLevel, message: impl AsRef<str>) {
-        self.client.log(level, message);
     }
 }
 

--- a/crates/freven_world_api/src/messages.rs
+++ b/crates/freven_world_api/src/messages.rs
@@ -1,5 +1,3 @@
-use crate::ClientPlayerView;
-use crate::ComponentId;
 /// Mod message scope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -119,12 +117,4 @@ where
     ) -> Result<(), ServerMessageSendError> {
         ServerMessageProvider::send_to(self, player_id, msg)
     }
-}
-
-/// Engine-provided player presentation query surface.
-pub trait ClientPlayerProvider {
-    fn list_players(&self, out: &mut Vec<ClientPlayerView>);
-    fn display_name_for(&self, player_id: u64) -> Option<String>;
-    fn component_bytes_for(&self, player_id: u64, component_id: ComponentId) -> Option<&[u8]>;
-    fn world_to_screen(&self, world_pos_m: (f32, f32, f32)) -> Option<(f32, f32)>;
 }

--- a/crates/freven_world_api/src/registration.rs
+++ b/crates/freven_world_api/src/registration.rs
@@ -1,22 +1,14 @@
-use std::sync::Arc;
-
 use freven_block_sdk_types::BlockDescriptor;
 use freven_mod_api::{
     CapabilityDeclaration, ChannelConfig, ChannelOrdering, ChannelReliability, ComponentCodec,
     MessageCodec, ModSide, Side,
 };
 use serde::de::DeserializeOwned;
+use std::{any::Any, sync::Arc};
 
 use crate::{
     action::{ActionHandler, ActionKindId},
-    character::{
-        CharacterController, CharacterControllerFactory, CharacterControllerInit,
-        ClientControlProvider, ClientControlProviderFactory, ClientControlProviderInit,
-    },
-    lifecycle::{
-        ClientMessagesHook, ServerMessagesHook, StartClientHook, StartServerHook, TickClientHook,
-        TickServerHook,
-    },
+    lifecycle::{ClientMessagesHook, ServerMessagesHook, StartServerHook, TickServerHook},
     worldgen::{WorldGenFactory, WorldGenInit, WorldGenProvider},
 };
 
@@ -66,17 +58,9 @@ pub struct MessageId(pub u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WorldGenId(pub u32);
 
-/// Numeric id for registered character controllers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct CharacterControllerId(pub u32);
-
 /// Numeric id for registered modnet channels.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ChannelId(pub u32);
-
-/// Numeric id for registered client control providers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ClientControlProviderId(pub u32);
 
 /// Message type registration config.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -118,16 +102,22 @@ pub trait ModContextBackend {
         key: &str,
         factory: WorldGenFactory,
     ) -> Result<WorldGenId, ModRegistrationError>;
-    fn register_character_controller(
+    #[doc(hidden)]
+    fn register_avatar_character_controller(
         &mut self,
         key: &str,
-        factory: CharacterControllerFactory,
-    ) -> Result<CharacterControllerId, ModRegistrationError>;
-    fn register_client_control_provider(
+        factory: Box<dyn Any + Send + Sync>,
+    ) -> Result<u32, ModRegistrationError>;
+    #[doc(hidden)]
+    fn register_avatar_client_control_provider(
         &mut self,
         key: &str,
-        factory: ClientControlProviderFactory,
-    ) -> Result<ClientControlProviderId, ModRegistrationError>;
+        factory: Box<dyn Any + Send + Sync>,
+    ) -> Result<u32, ModRegistrationError>;
+    #[doc(hidden)]
+    fn on_avatar_start_client(&mut self, hook: Box<dyn Any + Send + Sync>);
+    #[doc(hidden)]
+    fn on_avatar_tick_client(&mut self, hook: Box<dyn Any + Send + Sync>);
     fn register_channel(
         &mut self,
         key: &str,
@@ -143,9 +133,7 @@ pub trait ModContextBackend {
         &mut self,
         capability: CapabilityDeclaration,
     ) -> Result<(), ModRegistrationError>;
-    fn on_start_client(&mut self, hook: StartClientHook);
     fn on_start_server(&mut self, hook: StartServerHook);
-    fn on_tick_client(&mut self, hook: TickClientHook);
     fn on_tick_server(&mut self, hook: TickServerHook);
     fn on_client_messages(&mut self, hook: ClientMessagesHook);
     fn on_server_messages(&mut self, hook: ServerMessagesHook);
@@ -248,28 +236,34 @@ impl<'a> ModContext<'a> {
         self.backend.register_worldgen(key, Arc::new(factory))
     }
 
-    pub fn register_character_controller(
+    #[doc(hidden)]
+    pub fn __register_avatar_character_controller(
         &mut self,
         key: &str,
-        factory: impl Fn(CharacterControllerInit) -> Box<dyn CharacterController>
-        + Send
-        + Sync
-        + 'static,
-    ) -> Result<CharacterControllerId, ModRegistrationError> {
+        factory: Box<dyn Any + Send + Sync>,
+    ) -> Result<u32, ModRegistrationError> {
         self.backend
-            .register_character_controller(key, Arc::new(factory))
+            .register_avatar_character_controller(key, factory)
     }
 
-    pub fn register_client_control_provider(
+    #[doc(hidden)]
+    pub fn __register_avatar_client_control_provider(
         &mut self,
         key: &str,
-        factory: impl Fn(ClientControlProviderInit) -> Box<dyn ClientControlProvider>
-        + Send
-        + Sync
-        + 'static,
-    ) -> Result<ClientControlProviderId, ModRegistrationError> {
+        factory: Box<dyn Any + Send + Sync>,
+    ) -> Result<u32, ModRegistrationError> {
         self.backend
-            .register_client_control_provider(key, Arc::new(factory))
+            .register_avatar_client_control_provider(key, factory)
+    }
+
+    #[doc(hidden)]
+    pub fn __on_avatar_start_client(&mut self, hook: Box<dyn Any + Send + Sync>) {
+        self.backend.on_avatar_start_client(hook);
+    }
+
+    #[doc(hidden)]
+    pub fn __on_avatar_tick_client(&mut self, hook: Box<dyn Any + Send + Sync>) {
+        self.backend.on_avatar_tick_client(hook);
     }
 
     pub fn register_channel(
@@ -312,16 +306,8 @@ impl<'a> ModContext<'a> {
         self.backend.declare_capability(capability)
     }
 
-    pub fn on_start_client(&mut self, hook: StartClientHook) {
-        self.backend.on_start_client(hook);
-    }
-
     pub fn on_start_server(&mut self, hook: StartServerHook) {
         self.backend.on_start_server(hook);
-    }
-
-    pub fn on_tick_client(&mut self, hook: TickClientHook) {
-        self.backend.on_tick_client(hook);
     }
 
     pub fn on_tick_server(&mut self, hook: TickServerHook) {


### PR DESCRIPTION
## Summary
This PR establishes an explicit avatar-owned SDK layer in `freven-sdk` by introducing `freven_avatar_sdk_types` and `freven_avatar_api`, and by moving character/control/presentation-facing public contracts out of `freven_world_api`.

The new avatar layer now owns:
- avatar identity
- client input and control-provider contracts
- character-controller and character-physics contracts
- client-facing avatar presentation views and lifecycle APIs
- registration-facing helpers for avatar controllers, control providers, and client lifecycle hooks

At the same time, `freven_world_api` is narrowed back to world-owned concerns:
- remove world-owned public ownership of character/controller types
- remove world-owned client lifecycle API surface that actually belongs to avatar-facing client integration
- remove player-presentation and client-input/control contracts from the world layer
- keep only the hidden backend bridge points needed for runtime integration through avatar-owned registration extensions

Key changes:
- add `freven_avatar_sdk_types` for avatar identity, control, controller, and presentation contracts
- add `freven_avatar_api` as the public facade and registration/lifecycle entrypoint for those contracts
- extract former `freven_world_api::character` ownership into avatar-owned types
- move client lifecycle ownership for `start_client` / `tick_client` into the avatar API
- update `freven_world_api` registration plumbing so avatar-owned registrations flow through hidden backend hooks instead of world-owned public APIs
- document the ownership split so world remains world-owned and avatar-facing contracts stop leaking through the world layer

## Why
Stage 4.6 makes avatar character control and presentation a first-class semantic layer instead of continuing to treat those concerns as part of generic world ownership. This keeps the public SDK aligned with the intended architecture:
- `freven_world_api` stays focused on world-facing contracts
- avatar-facing client/control/controller/presentation contracts become explicitly avatar-owned
- downstream engine and vanilla integrations can now import the correct owner layer directly

## Notes for reviewers
This PR is primarily an ownership-boundary refactor in the public SDK. The most important review points are:
- whether the avatar-owned crates cleanly cover the extracted public surface
- whether `freven_world_api` no longer presents avatar/controller/presentation ownership publicly
- whether the hidden registration bridge in `ModContext` is sufficient for engine/runtime integration without re-exposing avatar ownership through the world layer