### PR TITLE
Restructure guest contracts around world and avatar ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[patch.unused]]
+name = "freven_vanilla_essentials"
+version = "0.1.0"
+
+[[patch.unused]]
 name = "freven_block_runtime"
 version = "0.1.0"
 
@@ -409,8 +413,4 @@ version = "0.1.0"
 
 [[patch.unused]]
 name = "freven_world_runtime"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "freven_vanilla_essentials"
 version = "0.1.0"

--- a/crates/freven_world_guest/src/lib.rs
+++ b/crates/freven_world_guest/src/lib.rs
@@ -52,12 +52,24 @@ pub struct GuestRegistration {
     pub blocks: Vec<BlockDeclaration>,
     pub components: Vec<ComponentDeclaration>,
     pub messages: Vec<MessageDeclaration>,
-    pub worldgen: Vec<WorldGenDeclaration>,
-    pub character_controllers: Vec<CharacterControllerDeclaration>,
-    pub client_control_providers: Vec<ClientControlProviderDeclaration>,
+    pub world: WorldGuestRegistration,
+    pub avatar: AvatarGuestRegistration,
     pub channels: Vec<ChannelDeclaration>,
     pub actions: Vec<ActionDeclaration>,
     pub capabilities: Vec<CapabilityDeclaration>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WorldGuestRegistration {
+    pub worldgen: Vec<WorldGenDeclaration>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AvatarGuestRegistration {
+    pub character_controllers: Vec<CharacterControllerDeclaration>,
+    pub client_control_providers: Vec<ClientControlProviderDeclaration>,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -70,7 +82,17 @@ pub struct GuestCallbacks {
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProviderHooks {
+    pub world: WorldProviderHooks,
+    pub avatar: AvatarProviderHooks,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorldProviderHooks {
     pub worldgen: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AvatarProviderHooks {
     pub character_controller: bool,
     pub client_control_provider: bool,
 }

--- a/crates/freven_world_guest/src/lib.rs
+++ b/crates/freven_world_guest/src/lib.rs
@@ -329,7 +329,6 @@ pub struct ActionInput<'a> {
     pub stream_epoch: u32,
     pub action_seq: u32,
     pub at_input_seq: u32,
-    pub player_position_m: Option<[f32; 3]>,
     #[serde(borrow)]
     pub payload: &'a [u8],
 }
@@ -530,27 +529,14 @@ pub enum RuntimeEntityTarget {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum WorldQueryRequest {
-    PlayerPosition {
-        player_id: u64,
-    },
-    PlayerDisplayName {
-        player_id: u64,
-    },
-    PlayerEntityId {
-        player_id: u64,
-    },
-    EntityComponentBytes {
-        entity: RuntimeEntityTarget,
-        component_key: String,
-    },
+    PlayerPosition { player_id: u64 },
+    PlayerDisplayName { player_id: u64 },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum WorldQueryResponse {
     PlayerPosition(Option<[f32; 3]>),
     PlayerDisplayName(Option<String>),
-    PlayerEntityId(Option<u32>),
-    EntityComponentBytes(Option<Vec<u8>>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/freven_world_guest_sdk/src/lib.rs
+++ b/crates/freven_world_guest_sdk/src/lib.rs
@@ -30,13 +30,13 @@ pub use freven_world_guest::{
     ClientPlayerView, ClientVisibilityRequest, ClientVisibilityResponse, GuestCallbacks,
     GuestDescription, GuestRegistration, InputTimeline, KinematicMoveConfig, KinematicMoveResult,
     LifecycleResult, MessageScope, ModConfigDocument, ModConfigFormat, NegotiationResponse,
-    ProviderHooks, RuntimeCharacterPhysicsRequest, RuntimeClientControlRequest,
-    RuntimeEntityTarget, RuntimeLevelRef, RuntimeMessageOutput, RuntimeObservabilityRequest,
-    RuntimeOutput, ServerInboundMessage, ServerMessageInput, ServerMessageResult,
-    ServerOutboundMessage, StartInput, SweepHit, TickInput, WorldGenCallInput, WorldGenCallResult,
-    WorldGenDeclaration, WorldGenInit, WorldGenOutput, WorldGenRequest, WorldGuestRegistration,
-    WorldProviderHooks, WorldQueryRequest, WorldQueryResponse, WorldServiceRequest,
-    WorldServiceResponse, WorldSessionRequest, WorldSessionResponse, WorldTerrainWrite,
+    ProviderHooks, RuntimeCharacterPhysicsRequest, RuntimeClientControlRequest, RuntimeLevelRef,
+    RuntimeMessageOutput, RuntimeObservabilityRequest, RuntimeOutput, ServerInboundMessage,
+    ServerMessageInput, ServerMessageResult, ServerOutboundMessage, StartInput, SweepHit,
+    TickInput, WorldGenCallInput, WorldGenCallResult, WorldGenDeclaration, WorldGenInit,
+    WorldGenOutput, WorldGenRequest, WorldGuestRegistration, WorldProviderHooks, WorldQueryRequest,
+    WorldQueryResponse, WorldServiceRequest, WorldServiceResponse, WorldSessionRequest,
+    WorldSessionResponse, WorldTerrainWrite,
 };
 use serde::de::DeserializeOwned;
 
@@ -1125,11 +1125,6 @@ impl<'a> ActionContext<'a> {
     }
 
     #[must_use]
-    pub fn player_position_m(&self) -> Option<[f32; 3]> {
-        self.input.player_position_m
-    }
-
-    #[must_use]
     pub fn payload(&self) -> &'a [u8] {
         self.input.payload
     }
@@ -1397,33 +1392,6 @@ impl RuntimeServices {
             WorldQueryRequest::PlayerDisplayName { player_id },
         )) {
             WorldServiceResponse::Query(WorldQueryResponse::PlayerDisplayName(value)) => value,
-            _ => None,
-        }
-    }
-
-    #[must_use]
-    pub fn player_entity_id(self, player_id: u64) -> Option<u32> {
-        match runtime_service_call(WorldServiceRequest::Query(
-            WorldQueryRequest::PlayerEntityId { player_id },
-        )) {
-            WorldServiceResponse::Query(WorldQueryResponse::PlayerEntityId(value)) => value,
-            _ => None,
-        }
-    }
-
-    #[must_use]
-    pub fn entity_component_bytes(
-        self,
-        entity: RuntimeEntityTarget,
-        component_key: &str,
-    ) -> Option<Vec<u8>> {
-        match runtime_service_call(WorldServiceRequest::Query(
-            WorldQueryRequest::EntityComponentBytes {
-                entity,
-                component_key: component_key.to_string(),
-            },
-        )) {
-            WorldServiceResponse::Query(WorldQueryResponse::EntityComponentBytes(value)) => value,
             _ => None,
         }
     }
@@ -4015,7 +3983,6 @@ mod tests {
             stream_epoch: 4,
             action_seq: 8,
             at_input_seq: 16,
-            player_position_m: None,
             payload: &[],
         };
 
@@ -4066,7 +4033,6 @@ mod tests {
             stream_epoch: 3,
             action_seq: 4,
             at_input_seq: 5,
-            player_position_m: Some([1.0, 2.0, 3.0]),
             payload: &[],
         });
 

--- a/crates/freven_world_guest_sdk/src/lib.rs
+++ b/crates/freven_world_guest_sdk/src/lib.rs
@@ -20,22 +20,23 @@ use freven_guest::{
     NegotiationRequest, RuntimeSessionInfo, RuntimeSessionSide,
 };
 pub use freven_world_guest::{
-    ActionDeclaration, ActionInput, ActionOutcome, ActionResult, BlockDeclaration, CharacterConfig,
-    CharacterControllerDeclaration, CharacterControllerInitInput, CharacterControllerInitResult,
-    CharacterControllerInput, CharacterControllerStepInput, CharacterControllerStepResult,
-    CharacterShape, CharacterState, ClientControlOutput, ClientControlProviderDeclaration,
-    ClientControlSampleInput, ClientControlSampleResult, ClientInboundMessage, ClientKeyCode,
-    ClientMessageInput, ClientMessageResult, ClientMouseButton, ClientOutboundMessage,
-    ClientOutboundMessageScope, ClientPlayerView, ClientVisibilityRequest,
-    ClientVisibilityResponse, GuestCallbacks, GuestDescription, GuestRegistration, InputTimeline,
-    KinematicMoveConfig, KinematicMoveResult, LifecycleResult, MessageScope, ModConfigDocument,
-    ModConfigFormat, NegotiationResponse, ProviderHooks, RuntimeCharacterPhysicsRequest,
-    RuntimeClientControlRequest, RuntimeEntityTarget, RuntimeLevelRef, RuntimeMessageOutput,
-    RuntimeObservabilityRequest, RuntimeOutput, ServerInboundMessage, ServerMessageInput,
-    ServerMessageResult, ServerOutboundMessage, StartInput, SweepHit, TickInput, WorldGenCallInput,
-    WorldGenCallResult, WorldGenDeclaration, WorldGenInit, WorldGenOutput, WorldGenRequest,
-    WorldQueryRequest, WorldQueryResponse, WorldServiceRequest, WorldServiceResponse,
-    WorldSessionRequest, WorldSessionResponse, WorldTerrainWrite,
+    ActionDeclaration, ActionInput, ActionOutcome, ActionResult, AvatarGuestRegistration,
+    AvatarProviderHooks, BlockDeclaration, CharacterConfig, CharacterControllerDeclaration,
+    CharacterControllerInitInput, CharacterControllerInitResult, CharacterControllerInput,
+    CharacterControllerStepInput, CharacterControllerStepResult, CharacterShape, CharacterState,
+    ClientControlOutput, ClientControlProviderDeclaration, ClientControlSampleInput,
+    ClientControlSampleResult, ClientInboundMessage, ClientKeyCode, ClientMessageInput,
+    ClientMessageResult, ClientMouseButton, ClientOutboundMessage, ClientOutboundMessageScope,
+    ClientPlayerView, ClientVisibilityRequest, ClientVisibilityResponse, GuestCallbacks,
+    GuestDescription, GuestRegistration, InputTimeline, KinematicMoveConfig, KinematicMoveResult,
+    LifecycleResult, MessageScope, ModConfigDocument, ModConfigFormat, NegotiationResponse,
+    ProviderHooks, RuntimeCharacterPhysicsRequest, RuntimeClientControlRequest,
+    RuntimeEntityTarget, RuntimeLevelRef, RuntimeMessageOutput, RuntimeObservabilityRequest,
+    RuntimeOutput, ServerInboundMessage, ServerMessageInput, ServerMessageResult,
+    ServerOutboundMessage, StartInput, SweepHit, TickInput, WorldGenCallInput, WorldGenCallResult,
+    WorldGenDeclaration, WorldGenInit, WorldGenOutput, WorldGenRequest, WorldGuestRegistration,
+    WorldProviderHooks, WorldQueryRequest, WorldQueryResponse, WorldServiceRequest,
+    WorldServiceResponse, WorldSessionRequest, WorldSessionResponse, WorldTerrainWrite,
 };
 use serde::de::DeserializeOwned;
 
@@ -404,9 +405,13 @@ impl GuestModule {
                 server: self.on_server_messages.is_some(),
             },
             providers: ProviderHooks {
-                worldgen: !self.worldgen_handlers.is_empty(),
-                character_controller: !self.character_controller_handlers.is_empty(),
-                client_control_provider: !self.client_control_provider_handlers.is_empty(),
+                world: WorldProviderHooks {
+                    worldgen: !self.worldgen_handlers.is_empty(),
+                },
+                avatar: AvatarProviderHooks {
+                    character_controller: !self.character_controller_handlers.is_empty(),
+                    client_control_provider: !self.client_control_provider_handlers.is_empty(),
+                },
             },
         }
     }
@@ -419,9 +424,13 @@ impl GuestModule {
                 blocks: self.blocks.clone(),
                 components: self.components.clone(),
                 messages: self.messages.clone(),
-                worldgen: self.worldgen.clone(),
-                character_controllers: self.character_controllers.clone(),
-                client_control_providers: self.client_control_providers.clone(),
+                world: WorldGuestRegistration {
+                    worldgen: self.worldgen.clone(),
+                },
+                avatar: AvatarGuestRegistration {
+                    character_controllers: self.character_controllers.clone(),
+                    client_control_providers: self.client_control_providers.clone(),
+                },
                 channels: self.channels.clone(),
                 actions: self
                     .actions
@@ -880,9 +889,16 @@ impl<S: 'static> StatefulGuestModule<S> {
                 server: self.on_server_messages.is_some(),
             },
             providers: ProviderHooks {
-                worldgen: !self.module.worldgen_handlers.is_empty(),
-                character_controller: !self.module.character_controller_handlers.is_empty(),
-                client_control_provider: !self.module.client_control_provider_handlers.is_empty(),
+                world: WorldProviderHooks {
+                    worldgen: !self.module.worldgen_handlers.is_empty(),
+                },
+                avatar: AvatarProviderHooks {
+                    character_controller: !self.module.character_controller_handlers.is_empty(),
+                    client_control_provider: !self
+                        .module
+                        .client_control_provider_handlers
+                        .is_empty(),
+                },
             },
         }
     }
@@ -896,9 +912,13 @@ impl<S: 'static> ExportedGuestModule for StatefulGuestModule<S> {
                 blocks: self.module.blocks.clone(),
                 components: self.module.components.clone(),
                 messages: self.module.messages.clone(),
-                worldgen: self.module.worldgen.clone(),
-                character_controllers: self.module.character_controllers.clone(),
-                client_control_providers: self.module.client_control_providers.clone(),
+                world: WorldGuestRegistration {
+                    worldgen: self.module.worldgen.clone(),
+                },
+                avatar: AvatarGuestRegistration {
+                    character_controllers: self.module.character_controllers.clone(),
+                    client_control_providers: self.module.client_control_providers.clone(),
+                },
                 channels: self.module.channels.clone(),
                 actions: self
                     .actions
@@ -2504,9 +2524,13 @@ macro_rules! export_wasm_guest {
                     server: $crate::export_wasm_guest!(@bool $($server_messages)?),
                 },
                 $crate::ProviderHooks {
-                    worldgen: $crate::export_wasm_guest!(@bool $($worldgen)?),
-                    character_controller: $crate::export_wasm_guest!(@bool $($character_controller)?),
-                    client_control_provider: $crate::export_wasm_guest!(@bool $($client_control_provider)?),
+                    world: $crate::WorldProviderHooks {
+                        worldgen: $crate::export_wasm_guest!(@bool $($worldgen)?),
+                    },
+                    avatar: $crate::AvatarProviderHooks {
+                        character_controller: $crate::export_wasm_guest!(@bool $($character_controller)?),
+                        client_control_provider: $crate::export_wasm_guest!(@bool $($client_control_provider)?),
+                    },
                 },
             );
             $crate::__private::wasm_guest_negotiate(&module, ptr, len)
@@ -2709,9 +2733,13 @@ macro_rules! export_native_guest {
                     server: $crate::export_native_guest!(@bool $($server_messages)?),
                 },
                 $crate::ProviderHooks {
-                    worldgen: $crate::export_native_guest!(@bool $($worldgen)?),
-                    character_controller: $crate::export_native_guest!(@bool $($character_controller)?),
-                    client_control_provider: $crate::export_native_guest!(@bool $($client_control_provider)?),
+                    world: $crate::WorldProviderHooks {
+                        worldgen: $crate::export_native_guest!(@bool $($worldgen)?),
+                    },
+                    avatar: $crate::AvatarProviderHooks {
+                        character_controller: $crate::export_native_guest!(@bool $($character_controller)?),
+                        client_control_provider: $crate::export_native_guest!(@bool $($client_control_provider)?),
+                    },
                 },
             );
             $crate::__private::native_guest_negotiate(&module, input)
@@ -3897,9 +3925,19 @@ mod tests {
         assert_eq!(description.registration.blocks.len(), 1);
         assert_eq!(description.registration.components.len(), 1);
         assert_eq!(description.registration.messages.len(), 1);
-        assert_eq!(description.registration.worldgen.len(), 1);
-        assert_eq!(description.registration.character_controllers.len(), 1);
-        assert_eq!(description.registration.client_control_providers.len(), 1);
+        assert_eq!(description.registration.world.worldgen.len(), 1);
+        assert_eq!(
+            description.registration.avatar.character_controllers.len(),
+            1
+        );
+        assert_eq!(
+            description
+                .registration
+                .avatar
+                .client_control_providers
+                .len(),
+            1
+        );
         assert_eq!(description.registration.channels.len(), 1);
         assert_eq!(description.registration.actions.len(), 1);
         assert_eq!(description.registration.capabilities.len(), 1);
@@ -4264,15 +4302,27 @@ mod tests {
         );
 
         let description = module.description();
-        assert_eq!(description.registration.worldgen.len(), 1);
-        assert_eq!(description.registration.character_controllers.len(), 1);
-        assert_eq!(description.registration.client_control_providers.len(), 1);
+        assert_eq!(description.registration.world.worldgen.len(), 1);
+        assert_eq!(
+            description.registration.avatar.character_controllers.len(),
+            1
+        );
+        assert_eq!(
+            description
+                .registration
+                .avatar
+                .client_control_providers
+                .len(),
+            1
+        );
         assert_eq!(
             description.callbacks.providers,
             ProviderHooks {
-                worldgen: true,
-                character_controller: true,
-                client_control_provider: true,
+                world: WorldProviderHooks { worldgen: true },
+                avatar: AvatarProviderHooks {
+                    character_controller: true,
+                    client_control_provider: true,
+                },
             }
         );
 
@@ -4345,9 +4395,11 @@ mod tests {
         assert_eq!(
             module.description().callbacks.providers,
             ProviderHooks {
-                worldgen: true,
-                character_controller: true,
-                client_control_provider: true,
+                world: WorldProviderHooks { worldgen: true },
+                avatar: AvatarProviderHooks {
+                    character_controller: true,
+                    client_control_provider: true,
+                },
             }
         );
     }

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -117,7 +117,6 @@ Current hosting policy:
 - `ActionResult.outcome` is `applied` or `rejected`
 - `ActionResult.output` carries canonical runtime output families
 - rejected actions may carry message output, but must not carry command output
-- `ActionInput.player_position_m` remains an action-scoped convenience slice, not the runtime service model
 
 ## Message path
 

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -122,7 +122,6 @@ message callbacks through `LifecycleResult.output`.
 - `stream_epoch: u32`
 - `action_seq: u32`
 - `at_input_seq: u32`
-- `player_position_m: Option<[f32; 3]>`
 - `payload: &[u8]` (opaque client/server action payload)
 
 ### Message callbacks


### PR DESCRIPTION
This PR realigns the public guest contract with the ownership split introduced across the SDK and runtime layers.

It replaces the old flat provider and registration model with explicit `world` and `avatar` families, so guest declarations now describe ownership boundaries directly instead of mixing unrelated surfaces in one namespace.

Concretely, this change:
- nests guest registration under `WorldGuestRegistration` and `AvatarGuestRegistration`
- nests provider callback declarations under `WorldProviderHooks` and `AvatarProviderHooks`
- updates guest-module description generation, native/wasm export macros, and test coverage to emit the new structure consistently
- removes stale generic convenience surfaces that no longer fit the ownership model, including `ActionInput.player_position_m`, `player_entity_id`, and generic `entity_component_bytes`
- narrows `WorldQueryRequest` and `WorldQueryResponse` to the remaining player-facing query surface that still belongs in this contract
- refreshes the guest contract and wasm ABI documentation to match the simplified interface

Overall, the result is a cleaner and more honest contract surface: world-owned and avatar-owned provider families are explicit, deprecated cross-ownership escape hatches are removed, and generated guest descriptions now align with the runtime ownership model end to end.