### PR TITLE
Add canonical worldgen initial spawn hint and persisted initial world spawn types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ version = "0.1.0"
 dependencies = [
  "freven_block_sdk_types",
  "freven_volumetric_sdk_types",
+ "postcard",
  "serde",
  "thiserror",
 ]

--- a/crates/freven_volumetric_api/Cargo.toml
+++ b/crates/freven_volumetric_api/Cargo.toml
@@ -14,3 +14,6 @@ freven_volumetric_sdk_types.workspace = true
 freven_block_sdk_types.workspace = true
 thiserror.workspace = true
 serde.workspace = true
+
+[dev-dependencies]
+postcard.workspace = true

--- a/crates/freven_volumetric_api/src/lib.rs
+++ b/crates/freven_volumetric_api/src/lib.rs
@@ -136,11 +136,37 @@ pub enum WorldTerrainWrite {
     },
 }
 
+/// Advisory bootstrap-oriented metadata emitted by a worldgen provider.
+///
+/// This family is transport-independent semantic contract. Hosts may consume or
+/// ignore it when bootstrapping a world's initial spawn state.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WorldGenBootstrapOutput {
+    /// Advisory hint for selecting an initial world bootstrap spawn.
+    pub initial_world_spawn_hint: Option<InitialWorldSpawnHint>,
+}
+
+/// Advisory initial world bootstrap spawn hint emitted by worldgen.
+///
+/// This hint is for initial world bootstrap semantics only. It is not a generic
+/// respawn policy, runtime spawn service, or lifecycle-owned spawn contract.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct InitialWorldSpawnHint {
+    /// Suggested world-space feet position in meters.
+    ///
+    /// This is the character feet position, not the collider center, capsule
+    /// origin, or any other body-local reference point.
+    pub feet_position: [f32; 3],
+}
+
 /// World-owned terrain generation output for one requested column.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct WorldGenOutput {
     pub writes: Vec<WorldTerrainWrite>,
+    /// Advisory bootstrap-oriented metadata for initial world bring-up.
+    pub bootstrap: WorldGenBootstrapOutput,
 }
 
 /// Worldgen contract error placeholder.
@@ -148,4 +174,40 @@ pub struct WorldGenOutput {
 #[error("worldgen error: {message}")]
 pub struct WorldGenError {
     pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        InitialWorldSpawnHint, WorldGenBootstrapOutput, WorldGenOutput, WorldTerrainWrite,
+    };
+    use freven_block_sdk_types::BlockRuntimeId;
+
+    #[test]
+    fn worldgen_output_postcard_roundtrip_preserves_bootstrap_hint() {
+        let output = WorldGenOutput {
+            writes: vec![WorldTerrainWrite::FillSection {
+                sy: 0.into(),
+                block_id: BlockRuntimeId(7),
+            }],
+            bootstrap: WorldGenBootstrapOutput {
+                initial_world_spawn_hint: Some(InitialWorldSpawnHint {
+                    feet_position: [12.5, 65.0, -3.25],
+                }),
+            },
+        };
+
+        let encoded = postcard::to_allocvec(&output).expect("postcard encode");
+        let decoded: WorldGenOutput = postcard::from_bytes(&encoded).expect("postcard decode");
+
+        assert_eq!(decoded, output);
+    }
+
+    #[test]
+    fn worldgen_output_default_has_no_bootstrap_hint() {
+        let output = WorldGenOutput::default();
+
+        assert!(output.bootstrap.initial_world_spawn_hint.is_none());
+        assert!(output.writes.is_empty());
+    }
 }

--- a/crates/freven_world_guest/src/lib.rs
+++ b/crates/freven_world_guest/src/lib.rs
@@ -32,7 +32,10 @@ use freven_guest::{
 use serde::{Deserialize, Serialize};
 
 /// Volumetric-owned worldgen contracts consumed by runtime-loaded guests.
-pub use freven_volumetric_api::{WorldGenInit, WorldGenOutput, WorldGenRequest, WorldTerrainWrite};
+pub use freven_volumetric_api::{
+    InitialWorldSpawnHint, WorldGenBootstrapOutput, WorldGenInit, WorldGenOutput, WorldGenRequest,
+    WorldTerrainWrite,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NegotiationResponse {
@@ -136,7 +139,7 @@ pub struct WorldGenCallInput {
     pub request: WorldGenRequest,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct WorldGenCallResult {
     pub output: WorldGenOutput,

--- a/crates/freven_world_guest_sdk/README.md
+++ b/crates/freven_world_guest_sdk/README.md
@@ -91,6 +91,8 @@ intentionally need to wire the raw surface yourself.
   capability keys in one transport-neutral registration model.
 - Worldgen output uses the same canonical terrain-write model as builtin
   worldgen: `WorldGenOutput.writes` plus
+  `WorldGenOutput.bootstrap.initial_world_spawn_hint` for advisory initial
+  world bootstrap spawn selection and
   `WorldTerrainWrite::{FillSection, FillBox, SetBlock}`.
 - Those `WorldGen*` structures are owned by `freven_volumetric_api`; this SDK
   merely re-exports them so world-layer guests can author against the same

--- a/crates/freven_world_guest_sdk/src/lib.rs
+++ b/crates/freven_world_guest_sdk/src/lib.rs
@@ -19,7 +19,10 @@ use freven_guest::{
     LifecycleHooks, LogLevel, LogPayload, MessageCodec, MessageDeclaration, MessageHooks,
     NegotiationRequest, RuntimeSessionInfo, RuntimeSessionSide,
 };
-pub use freven_volumetric_api::{WorldGenInit, WorldGenOutput, WorldGenRequest, WorldTerrainWrite};
+pub use freven_volumetric_api::{
+    InitialWorldSpawnHint, WorldGenBootstrapOutput, WorldGenInit, WorldGenOutput, WorldGenRequest,
+    WorldTerrainWrite,
+};
 pub use freven_world_guest::{
     ActionDeclaration, ActionInput, ActionOutcome, ActionResult, AvatarGuestRegistration,
     AvatarProviderHooks, BlockDeclaration, CharacterConfig, CharacterControllerDeclaration,
@@ -3838,6 +3841,11 @@ mod tests {
                     sy: 0.into(),
                     block_id: BlockRuntimeId(7),
                 }],
+                bootstrap: WorldGenBootstrapOutput {
+                    initial_world_spawn_hint: Some(InitialWorldSpawnHint {
+                        feet_position: [0.5, 65.0, 0.5],
+                    }),
+                },
             },
         }
     }
@@ -4305,6 +4313,12 @@ mod tests {
             }
             write => panic!("unexpected worldgen write: {write:?}"),
         }
+        assert_eq!(
+            worldgen.output.bootstrap.initial_world_spawn_hint,
+            Some(InitialWorldSpawnHint {
+                feet_position: [0.5, 65.0, 0.5],
+            })
+        );
 
         let init = module.handle_character_controller_init(CharacterControllerInitInput {
             key: "freven.test:humanoid".to_string(),

--- a/crates/freven_world_sdk_types/src/save.rs
+++ b/crates/freven_world_sdk_types/src/save.rs
@@ -3,6 +3,53 @@ use serde::{Deserialize, Serialize};
 pub const WORLD_SAVE_FORMAT_VERSION: u32 = 1;
 pub const DIMENSION_SAVE_FORMAT_VERSION: u32 = 1;
 pub const DEFAULT_PRIMARY_DIMENSION_ID: &str = "overworld";
+const MM_PER_METER: f32 = 1000.0;
+
+/// Persisted, host-resolved initial world spawn for a world save.
+///
+/// - This is world-owned truth (not advisory worldgen output).
+/// - Position is the world-space feet position quantized to millimeters.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InitialWorldSpawn {
+    pub feet_position_mm: [i32; 3],
+    #[serde(default = "default_initial_world_spawn_dimension_id")]
+    pub dimension_id: String,
+}
+
+impl InitialWorldSpawn {
+    #[must_use]
+    pub fn from_feet_position_meters(feet_position_m: [f32; 3]) -> Self {
+        Self::from_feet_position_meters_in_dimension(feet_position_m, DEFAULT_PRIMARY_DIMENSION_ID)
+    }
+
+    #[must_use]
+    pub fn from_feet_position_meters_in_dimension(
+        feet_position_m: [f32; 3],
+        dimension_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            feet_position_mm: [
+                meters_to_mm(feet_position_m[0]),
+                meters_to_mm(feet_position_m[1]),
+                meters_to_mm(feet_position_m[2]),
+            ],
+            dimension_id: dimension_id.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn feet_position_meters(&self) -> [f32; 3] {
+        [
+            self.feet_position_mm[0] as f32 / MM_PER_METER,
+            self.feet_position_mm[1] as f32 / MM_PER_METER,
+            self.feet_position_mm[2] as f32 / MM_PER_METER,
+        ]
+    }
+}
+
+fn default_initial_world_spawn_dimension_id() -> String {
+    String::new()
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorldSaveMetadata {
@@ -11,6 +58,8 @@ pub struct WorldSaveMetadata {
     pub seed: u64,
     pub bound_experience_id: String,
     pub primary_dimension_id: String,
+    #[serde(default)]
+    pub initial_world_spawn: Option<InitialWorldSpawn>,
 }
 
 impl WorldSaveMetadata {
@@ -27,6 +76,7 @@ impl WorldSaveMetadata {
             seed,
             bound_experience_id,
             primary_dimension_id,
+            initial_world_spawn: None,
         }
     }
 }
@@ -88,5 +138,35 @@ impl DimensionLayoutSpec {
         Self {
             dimension_id: DEFAULT_PRIMARY_DIMENSION_ID.to_string(),
         }
+    }
+}
+
+fn meters_to_mm(value: f32) -> i32 {
+    let mm = (value * MM_PER_METER).round();
+    let bounded = mm.clamp(i32::MIN as f32, i32::MAX as f32);
+    bounded as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_PRIMARY_DIMENSION_ID, InitialWorldSpawn, WorldSaveMetadata};
+
+    #[test]
+    fn initial_world_spawn_meter_roundtrip_is_mm_quantized() {
+        let spawn = InitialWorldSpawn::from_feet_position_meters([12.3456, 64.0004, -7.8912]);
+        assert_eq!(spawn.feet_position_mm, [12346, 64000, -7891]);
+        assert_eq!(spawn.dimension_id, DEFAULT_PRIMARY_DIMENSION_ID);
+        assert_eq!(spawn.feet_position_meters(), [12.346, 64.0, -7.891]);
+    }
+
+    #[test]
+    fn world_save_metadata_defaults_to_unresolved_initial_spawn() {
+        let metadata = WorldSaveMetadata::new(
+            "world_0".to_string(),
+            7,
+            "exp.main".to_string(),
+            "overworld".to_string(),
+        );
+        assert!(metadata.initial_world_spawn.is_none());
     }
 }

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -242,6 +242,7 @@ Current block-mutation family carried by runtime output includes:
 Current worldgen output family uses:
 
 - `WorldGenOutput.writes`
+- `WorldGenOutput.bootstrap.initial_world_spawn_hint`
 - `WorldTerrainWrite::FillSection { sy, block_id }`
 - `WorldTerrainWrite::FillBox { min, max, block_id }`
 - `WorldTerrainWrite::SetBlock { pos, block_id }`
@@ -249,6 +250,11 @@ Current worldgen output family uses:
 Ownership note: these structs live in `freven_volumetric_api`. The world guest
 contract consumes them but does not own the volumetric topology or section
 layout semantics.
+
+`initial_world_spawn_hint` is advisory bootstrap metadata for initial world
+bring-up only. Its `feet_position` is a world-space feet position, not a
+collider center. Hosts resolve and persist a world-owned initial spawn from this
+hint family; later worldgen hints do not redefine runtime spawn policy.
 
 Worldgen provider execution concurrency is defined separately in
 `WORLDGEN_PROVIDER_CONCURRENCY_v1.md`. The current canonical mode is

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -166,10 +166,13 @@ Ownership note:
 Current worldgen output family:
 
 - `WorldGenOutput.writes`
+- `WorldGenOutput.bootstrap.initial_world_spawn_hint`
 - `WorldTerrainWrite::{FillSection, FillBox, SetBlock}`
 
 These volumetric structures live in `freven_volumetric_api` and are re-exported
 through the guest contract; the Wasm ABI keeps that ownership split intact.
+The bootstrap hint is advisory initial-world metadata; `feet_position` is the
+world-space feet point, not a collider center.
 
 Current message families:
 

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -137,6 +137,9 @@ It also owns the current world runtime helpers:
 
 `WorldGenOutput`/`WorldTerrainWrite` come from the volumetric-owned
 `freven_volumetric_api` crate; the world guest SDK simply re-exports them.
+That includes `WorldGenOutput.bootstrap.initial_world_spawn_hint`, an advisory
+initial world bootstrap feet-position hint rather than a generic respawn
+policy.
 
 Those surfaces are intentionally not available from the neutral
 `freven_guest_sdk` crate.


### PR DESCRIPTION
## Summary

This PR adds the canonical SDK-side contract for initial world spawn bootstrap.

It introduces:
- an advisory worldgen bootstrap hint on `WorldGenOutput`
- a persisted world-owned `InitialWorldSpawn` record in save metadata
- guest/world SDK re-exports and documentation updates so the contract is transport-independent and author-visible

This closes the contract gap tracked by issue [freven-devkit#20](https://github.com/frevenengine/freven-devkit/issues/20) on the SDK side.

## What changed

### Volumetric worldgen contract
Added canonical advisory bootstrap metadata:
- `WorldGenBootstrapOutput`
- `InitialWorldSpawnHint`
- `WorldGenOutput.bootstrap.initial_world_spawn_hint`

Semantics:
- advisory only
- initial-world-bootstrap only
- feet-position based
- not a generic respawn/runtime spawn service

### World save types
Added persisted world-owned spawn record:
- `InitialWorldSpawn`
- `WorldSaveMetadata.initial_world_spawn: Option<InitialWorldSpawn>`

Current persisted shape stores:
- world-space feet position quantized to millimeters
- dimension id for persisted ownership truth

### Guest / SDK surface
Re-exported the new worldgen bootstrap types through:
- `freven_world_guest`
- `freven_world_guest_sdk`

This keeps ownership in the canonical volumetric/world save crates while making the surface available to runtime-loaded guest authors.

### Documentation
Updated:
- `docs/GUEST_CONTRACT_v1.md`
- `docs/WASM_ABI_v1.md`
- `docs/WASM_AUTHORING.md`
- `freven_world_guest_sdk/README.md`

The docs now explicitly state:
- hint is advisory
- host resolves authoritative initial spawn
- later worldgen calls do not redefine runtime spawn policy

## Validation

Ran:
- `cargo +stable fmt --all`
- `cargo +stable test --workspace`
- `cargo +stable clippy --workspace --all-targets --all-features -- -D warnings`

## Scope / non-goals

This PR does **not** add:
- engine-side bootstrap resolution
- persistence wiring in runtime/server startup
- respawn providers or runtime spawn services
- broader lifecycle spawn policy

Those pieces are handled in follow-up repo changes for the same issue.

## Issue

Closes the SDK portion of [freven-devkit#20](https://github.com/frevenengine/freven-devkit/issues/20).