### PR TITLE
Docs: describe workload-scoped wasm capability profiles

### DIFF
--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -220,26 +220,70 @@ crashing or destabilizing the runtime.
 
 ## Capability policy (implemented in `freven_runtime_wasm`)
 
+Capabilities are host policy requests, not arbitrary guest runtime knobs.
 Runtime accepts only these capability keys:
 
-- `max_call_millis` (integer, must be `> 0`, cannot exceed host policy max)
-- `max_linear_memory_bytes` (integer, must be `> 0`, cannot exceed host policy max)
-- `allow_unstable` (boolean, must be `false`)
+- default/hot callback profile:
+  `max_call_millis`, `max_linear_memory_bytes`
+- worldgen provider profile:
+  `worldgen_max_call_millis`, `worldgen_max_linear_memory_bytes`,
+  `worldgen_max_result_bytes`
+- global validation flag:
+  `allow_unstable`
+
+Accepted types and base validation:
+
+- `max_call_millis`: integer, must be `> 0`, cannot exceed host policy max
+- `max_linear_memory_bytes`: integer, must be `> 0`, cannot exceed host policy max
+- `worldgen_max_call_millis`: integer, must be `> 0`, cannot exceed host policy max
+- `worldgen_max_linear_memory_bytes`: integer, must be `> 0`, cannot exceed host policy max
+- `worldgen_max_result_bytes`: integer, must be `> 0`, cannot exceed host policy max
+- `allow_unstable`: boolean, must be `false`
 
 Unknown keys are rejected. Invalid types are rejected.
 Declared capability keys must also exist in the resolved capability table; the
 runtime reports that as an explicit capability-declaration error rather than a duplicate-key error.
 
-Current host policy maxima/defaults:
+Current host policy by workload:
 
-- `max_call_millis`: `25`
-- `max_linear_memory_bytes`: `4 MiB`
+- default/hot callback profile
+- applies to lifecycle, tick, action, message, character-controller, and
+  client-control style interactive callbacks
+- supported keys: `max_call_millis`, `max_linear_memory_bytes`
+- current policy:
+  `max_call_millis = 25`, `max_linear_memory_bytes = 4 MiB`,
+  result bytes = `256 KiB`
+
+- worldgen provider profile
+- applies only to declared worldgen providers
+- supported keys:
+  `worldgen_max_call_millis`, `worldgen_max_linear_memory_bytes`,
+  `worldgen_max_result_bytes`
+- current policy defaults:
+  `worldgen_max_call_millis = 100`, `worldgen_max_linear_memory_bytes = 64 MiB`,
+  `worldgen_max_result_bytes = 1 MiB`
+- current policy maxima:
+  `worldgen_max_call_millis = 250`,
+  `worldgen_max_linear_memory_bytes = 128 MiB`,
+  `worldgen_max_result_bytes = 4 MiB`
+
+Additional host limits remain:
+
 - `max_negotiation_bytes`: `64 KiB`
-- `max_result_bytes`: `256 KiB`
 - `max_input_payload_bytes`: `64 KiB`
 - `max_block_mutations`: `128` entries, applied to `RuntimeOutput.blocks.mutations`
 
-Capabilities may tighten selected limits (`max_call_millis`, `max_linear_memory_bytes`) but cannot raise limits above policy maxima.
+Capability-profile rules:
+
+- old `max_*` keys do not raise worldgen limits
+- `worldgen_*` keys do not raise default/hot callback limits
+- `worldgen_*` keys require the guest to declare a worldgen provider
+- a both-side mod may declare `worldgen_*` keys and still attach on the client
+  side; the client side simply does not host the worldgen runner
+
+Capabilities may tighten selected limits and may request wider worldgen limits
+within host policy maxima, but they cannot raise any workload above that
+workload's policy ceiling.
 
 ## Security defaults (WP7A)
 

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -108,6 +108,59 @@ What stays explicit:
 magical. The hooks and registrations you write are the same data used to build
 the canonical `GuestDescription` and to emit the Wasm export surface.
 
+## Capability requests
+
+Declare Wasm capabilities in `mod.toml` as host policy requests, not as
+arbitrary guest-controlled runtime knobs.
+
+Current accepted capability keys are:
+
+- default/hot callback profile:
+  `max_linear_memory_bytes`, `max_call_millis`
+- worldgen provider profile:
+  `worldgen_max_linear_memory_bytes`, `worldgen_max_call_millis`,
+  `worldgen_max_result_bytes`
+- global validation flag:
+  `allow_unstable`
+
+Default/hot callback profile:
+
+- applies to lifecycle, tick, action, message, character-controller, and
+  client-control style interactive callbacks
+- current policy:
+  memory = `4 MiB`, call watchdog = `25 ms`, result bytes = `256 KiB`
+
+Worldgen provider profile:
+
+- applies only to declared worldgen providers
+- current policy defaults:
+  memory = `64 MiB`, call watchdog = `100 ms`, result bytes = `1 MiB`
+- current policy maxima:
+  memory = `128 MiB`, call watchdog = `250 ms`, result bytes = `4 MiB`
+
+Rules that matter in practice:
+
+- unknown capability keys are rejected
+- invalid value types are rejected
+- `allow_unstable` must remain `false`
+- old `max_*` keys do not raise worldgen limits
+- `worldgen_*` keys do not raise default/hot callback limits
+- `worldgen_*` keys require a declared worldgen provider
+- a both-side mod may declare `worldgen_*` keys and still attach on the client
+  side; the client side just does not host the worldgen runner
+
+Example:
+
+```toml
+[capabilities]
+max_linear_memory_bytes = 4194304
+max_call_millis = 25
+worldgen_max_linear_memory_bytes = 67108864
+worldgen_max_call_millis = 100
+worldgen_max_result_bytes = 1048576
+allow_unstable = false
+```
+
 ## World authoring details
 
 `freven_world_guest_sdk` exposes the current world-stack registration families

--- a/docs/WORLDGEN_PROVIDER_CONCURRENCY_v1.md
+++ b/docs/WORLDGEN_PROVIDER_CONCURRENCY_v1.md
@@ -26,6 +26,12 @@ execution itself.
 A provider session is the host-owned logical execution context for one active
 worldgen provider identity within one active runtime/world binding.
 
+For Wasm guests, workload-scoped `worldgen_*` capability requests apply only
+when the runtime actually hosts that worldgen provider. A both-side mod may
+declare a worldgen provider and `worldgen_*` requests while still attaching on
+the client side; that client attachment does not create a client-side worldgen
+provider session.
+
 In the current model, a host may realize that session as:
 - one builtin provider instance bound to one active world/session, or
 - one hosted runtime-loaded guest worldgen session wrapped by transport/runtime-specific plumbing.


### PR DESCRIPTION
Documents the workload-scoped wasm capability model introduced in freven-engine.

## What this adds

Clarifies how capability keys are interpreted by the runtime:

### Profiles

**DefaultInteractive**
- `max_linear_memory_bytes`
- `max_call_millis`
- applies to lifecycle / tick / action / message callbacks
- current policy: 4 MiB / 25 ms / 256 KiB

**WorldgenProvider**
- `worldgen_max_linear_memory_bytes`
- `worldgen_max_call_millis`
- `worldgen_max_result_bytes`
- applies only to declared worldgen providers
- current policy:
  - defaults: 64 MiB / 100 ms / 1 MiB
  - maxima:   128 MiB / 250 ms / 4 MiB

## Rules (author-facing)

- capabilities are **host policy requests**, not arbitrary knobs
- unknown keys -> rejected
- invalid types -> rejected
- `allow_unstable` must remain `false`
- `max_*` does not affect worldgen limits
- `worldgen_*` does not affect interactive callbacks
- `worldgen_*` requires a declared worldgen provider
- both-side mods may declare worldgen and still attach on client
  (client does not host worldgen session)

## Files updated

- `WASM_ABI_v1.md`
- `WASM_AUTHORING.md`
- `WORLDGEN_PROVIDER_CONCURRENCY_v1.md`

No code changes.

---

Completes docs for frevenengine/freven-devkit#6