### PR TITLE
[Docs] Add runtime-loaded Wasm disk layout and wiring examples

### DIFF
--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -108,6 +108,81 @@ What stays explicit:
 magical. The hooks and registrations you write are the same data used to build
 the canonical `GuestDescription` and to emit the Wasm export surface.
 
+
+## Disk layout and authored wiring
+
+There are two common disk layouts for runtime-loaded Wasm mods.
+
+### Instance-local mod in a mutable install
+
+Use this when you drop a mod into an install under `<instance>/mods/<mod_id>/...`.
+
+```text
+<instance>/
+  experiences/<experience_id>/experience.toml
+  mods/example.hello/
+    mod.toml
+    mod.wasm
+```
+
+Minimal `mod.toml`:
+
+```toml
+schema = 3
+id = "example.hello"
+version = "0.1.0"
+artifact = "wasm_module"
+execution = "wasm_guest"
+trust = "sandboxed"
+policy = "safe_guest"
+surfaces = "both"
+entry = "mod.wasm"
+```
+
+Reference it from the active experience by id/version:
+
+```toml
+[[mods]]
+id = "example.hello"
+version = "^0.1"
+```
+
+Runtime config belongs in the active experience:
+
+```toml
+[config."example.hello"]
+greeting = "hello"
+tick_every = 1
+```
+
+### Bundled product-owned mod inside an experience
+
+Use this when a bundled/shipped experience owns the mod subtree itself.
+
+```text
+<experience_root>/
+  experience.toml
+  mods/example.standalone.shell.core/
+    mod.toml
+    mod.wasm
+```
+
+Reference it with an explicit relative manifest path:
+
+```toml
+[[mods]]
+id = "example.standalone.shell.core"
+version = "^0.1"
+path = "mods/example.standalone.shell.core/mod.toml"
+```
+
+Notes:
+- `mod.toml` is the manifest / capability-request surface, not the active runtime config document.
+- Guest `StartInput.config` comes from `experience.config."<mod_id>"`.
+- Declare `[capabilities]` only when you need non-default limits or worldgen-specific budgets.
+- Use `surfaces = "server"` for server-only mods.
+  Use `surfaces = "both"` only when the guest is meant to attach on both sides.
+
 ## Capability requests
 
 Declare Wasm capabilities in `mod.toml` as host policy requests, not as


### PR DESCRIPTION
## Summary

Add runtime-loaded Wasm disk layout and authored wiring examples to the public
Wasm authoring docs.

Part of frevenengine/freven-devkit#49.

## What changed

- document the minimal instance-local runtime-loaded Wasm disk layout
- document the minimal current `mod.toml` shape
- show active-experience id/version wiring
- show that guest runtime config belongs in `experience.config."<mod_id>"`
- document the bundled product-owned experience-owned mod layout separately

## Why

The SDK docs already described Wasm authoring and capability requests, but they
did not yet show the concrete disk layout / manifest wiring shape that authors
need when moving from guest code to a real install or bundled experience.

This keeps the authoring contract discoverable from both the DevKit templates
and the canonical Wasm authoring docs.

## Validation

- reviewed the new docs section in `docs/WASM_AUTHORING.md`
- verified it now covers:
  - instance-local mutable install layout
  - bundled product-owned experience layout
  - current `schema = 3` manifest shape
  - explicit config ownership guidance