### PR TITLE
[Docs] Add worldgen initial spawn hint authoring examples

### DIFF
--- a/crates/freven_world_guest_sdk/README.md
+++ b/crates/freven_world_guest_sdk/README.md
@@ -67,6 +67,48 @@ registration: {
 remain available for lower-level fixtures and ABI-focused tests when you
 intentionally need to wire the raw surface yourself.
 
+
+## Initial world spawn hints for worldgen
+
+Worldgen providers may return an advisory initial bootstrap spawn hint through
+`WorldGenOutput.bootstrap.initial_world_spawn_hint`.
+
+Example:
+
+```rust
+use freven_world_guest_sdk::{
+    InitialWorldSpawnHint,
+    WorldGenBootstrapOutput,
+    WorldGenOutput,
+};
+
+fn finish_worldgen(
+    writes: Vec<freven_world_guest_sdk::WorldTerrainWrite>,
+    surface_y: f32,
+) -> WorldGenOutput {
+    WorldGenOutput {
+        writes,
+        bootstrap: WorldGenBootstrapOutput {
+            initial_world_spawn_hint: Some(InitialWorldSpawnHint {
+                feet_position: [16.5, surface_y + 2.0, 16.5],
+            }),
+        },
+    }
+}
+```
+
+Semantics that matter:
+- advisory only
+- initial world bootstrap only
+- `feet_position` is world-space feet position
+- host may validate/correct the final resolved spawn
+- later worldgen calls do not redefine runtime spawn policy
+
+Recommended strategy:
+- return a natural safe surface candidate from your terrain generator
+- do not flatten terrain around origin just to force safe spawning
+- treat the hint as bootstrap advice, not guaranteed final spawn ownership
+
 ## Current boundaries
 
 - Lifecycle hooks return `LifecycleResult`.

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -269,6 +269,53 @@ That includes `WorldGenOutput.bootstrap.initial_world_spawn_hint`, an advisory
 initial world bootstrap feet-position hint rather than a generic respawn
 policy.
 
+
+### Initial world spawn hints for custom worldgen providers
+
+Custom worldgen providers may return an advisory initial bootstrap spawn hint
+through `WorldGenOutput.bootstrap.initial_world_spawn_hint`.
+
+Example:
+
+```rust
+use freven_world_guest_sdk::{
+    InitialWorldSpawnHint,
+    WorldGenBootstrapOutput,
+    WorldGenOutput,
+};
+
+fn finish_worldgen(
+    writes: Vec<freven_world_guest_sdk::WorldTerrainWrite>,
+    surface_y: f32,
+) -> WorldGenOutput {
+    WorldGenOutput {
+        writes,
+        bootstrap: WorldGenBootstrapOutput {
+            initial_world_spawn_hint: Some(InitialWorldSpawnHint {
+                feet_position: [16.5, surface_y + 2.0, 16.5],
+            }),
+        },
+    }
+}
+```
+
+What this means:
+- this is for **initial world bootstrap** only, not general respawn policy
+- `feet_position` is a world-space **feet** position, not a collider center
+- the host resolves authoritative initial spawn and may validate or adjust the
+  final result against loaded terrain
+- current bootstrap flow explicitly probes the bootstrap worldgen column and
+  consumes the hint from that bootstrap bring-up path; later worldgen calls do
+  not redefine runtime spawn policy
+
+Recommended strategy:
+- return a natural safe candidate from your terrain generator, such as a known
+  walkable surface point with standing room
+- prefer a plausible gameplay spawn area rather than flattening terrain around
+  `(0, 0)` just to force safe spawning
+- treat the hint as advice to bootstrap resolution, not as a guarantee that the
+  exact returned feet position will be used unchanged
+
 Those surfaces are intentionally not available from the neutral
 `freven_guest_sdk` crate.
 


### PR DESCRIPTION
## Summary

Add short author-facing examples for returning an advisory initial world spawn
hint from custom worldgen providers.

Part of #45.

## What changed

- add an initial-world-spawn-hint authoring example to `docs/WASM_AUTHORING.md`
- add the same author-facing example to `crates/freven_world_guest_sdk/README.md`
- document the semantics that matter in practice:
  - advisory only
  - initial world bootstrap only
  - `feet_position` is world-space feet position
  - host may validate/correct the final resolved spawn
  - later worldgen calls do not redefine runtime spawn policy
- document the recommended strategy for custom terrain generators:
  return a natural safe candidate instead of flattening terrain around origin
  just to force safe spawning

## Why

The contract and runtime support for `WorldGenOutput.bootstrap.initial_world_spawn_hint`
already exist, but the authoring flow for custom worldgen providers was still
not obvious from the public SDK docs.

This PR closes that gap with the smallest working example in the main author-facing
Wasm/world guest docs.

## Validation

- reviewed updated `docs/WASM_AUTHORING.md`
- reviewed updated `crates/freven_world_guest_sdk/README.md`
- verified both now contain:
  - a concrete `WorldGenOutput { writes, bootstrap: ... }` example
  - explicit bootstrap-only / advisory-only semantics
  - spawn-hint strategy guidance for custom worldgen authors