### PR TITLE
[Docs] Clarify WorldTerrainWrite::FillBox bounds semantics

### DIFF
--- a/crates/freven_volumetric_api/src/lib.rs
+++ b/crates/freven_volumetric_api/src/lib.rs
@@ -121,15 +121,42 @@ impl WorldGenRequest {
 /// Standard block/profile ids are imported from `freven_block_sdk_types`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WorldTerrainWrite {
+    /// Fill one whole canonical 32x32x32 section with one block id.
+    ///
+    /// Use this when the entire requested section volume is uniform.
     FillSection {
         sy: SectionY,
         block_id: BlockRuntimeId,
     },
+    /// Fill an axis-aligned box in absolute world-cell coordinates.
+    ///
+    /// Bounds are half-open on every axis: `[min, max)`.
+    ///
+    /// That means:
+    /// - `min` is inclusive
+    /// - `max` is exclusive
+    /// - each axis must satisfy `min < max`
+    /// - `min == max` is invalid because it produces zero volume
+    ///
+    /// Minimum valid box extent is therefore `1` on every axis.
+    ///
+    /// For a vertical run in one `(x, z)` column, use:
+    /// - `max.x = min.x + 1`
+    /// - `max.z = min.z + 1`
+    /// - `max.y = end_y_exclusive`
+    ///
+    /// Prefer `FillBox` for contiguous rectangular/column runs. Prefer
+    /// `SetBlock` for sparse or irregular writes. Prefer `FillSection` when a
+    /// whole section is uniform.
     FillBox {
         min: WorldCellPos,
         max: WorldCellPos,
         block_id: BlockRuntimeId,
     },
+    /// Write one absolute world cell.
+    ///
+    /// Prefer this for sparse or isolated writes. For contiguous rectangular
+    /// regions, `FillBox` is usually a better worldgen output shape.
     SetBlock {
         pos: WorldCellPos,
         block_id: BlockRuntimeId,

--- a/crates/freven_world_guest_sdk/README.md
+++ b/crates/freven_world_guest_sdk/README.md
@@ -68,6 +68,39 @@ remain available for lower-level fixtures and ABI-focused tests when you
 intentionally need to wire the raw surface yourself.
 
 
+
+## `WorldTerrainWrite::FillBox` bounds semantics
+
+`WorldTerrainWrite::FillBox` uses half-open bounds in absolute world-cell
+space: `[min, max)`.
+
+Example vertical run for one `(x, z)` column:
+
+```rust
+use freven_world_guest_sdk::{WorldCellPos, WorldTerrainWrite};
+
+let write = WorldTerrainWrite::FillBox {
+    min: WorldCellPos::new(x, start_y, z),
+    max: WorldCellPos::new(x + 1, end_y_exclusive, z + 1),
+    block_id,
+};
+```
+
+Semantics that matter:
+- `min` is inclusive
+- `max` is exclusive
+- `min == max` is invalid
+- minimum valid box extent is `1` on every axis
+- coordinates are absolute world-cell positions
+
+Recommended usage:
+- `SetBlock` for sparse/isolated cells
+- `FillBox` for contiguous rectangular regions or vertical runs
+- `FillSection` when one full section is uniform
+
+Do not treat `max` as an inclusive last block coordinate.
+
+
 ## Initial world spawn hints for worldgen
 
 Worldgen providers may return an advisory initial bootstrap spawn hint through

--- a/crates/freven_world_guest_sdk/README.md
+++ b/crates/freven_world_guest_sdk/README.md
@@ -67,6 +67,48 @@ registration: {
 remain available for lower-level fixtures and ABI-focused tests when you
 intentionally need to wire the raw surface yourself.
 
+
+## Initial world spawn hints for worldgen
+
+Worldgen providers may return an advisory initial bootstrap spawn hint through
+`WorldGenOutput.bootstrap.initial_world_spawn_hint`.
+
+Example:
+
+```rust
+use freven_world_guest_sdk::{
+    InitialWorldSpawnHint,
+    WorldGenBootstrapOutput,
+    WorldGenOutput,
+};
+
+fn finish_worldgen(
+    writes: Vec<freven_world_guest_sdk::WorldTerrainWrite>,
+    surface_y: f32,
+) -> WorldGenOutput {
+    WorldGenOutput {
+        writes,
+        bootstrap: WorldGenBootstrapOutput {
+            initial_world_spawn_hint: Some(InitialWorldSpawnHint {
+                feet_position: [16.5, surface_y + 2.0, 16.5],
+            }),
+        },
+    }
+}
+```
+
+Semantics that matter:
+- advisory only
+- initial world bootstrap only
+- `feet_position` is world-space feet position
+- host may validate/correct the final resolved spawn
+- later worldgen calls do not redefine runtime spawn policy
+
+Recommended strategy:
+- return a natural safe surface candidate from your terrain generator
+- do not flatten terrain around origin just to force safe spawning
+- treat the hint as bootstrap advice, not guaranteed final spawn ownership
+
 ## Current boundaries
 
 - Lifecycle hooks return `LifecycleResult`.

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -247,6 +247,11 @@ Current worldgen output family uses:
 - `WorldTerrainWrite::FillBox { min, max, block_id }`
 - `WorldTerrainWrite::SetBlock { pos, block_id }`
 
+`WorldTerrainWrite::FillBox` uses half-open absolute world-cell bounds:
+`[min, max)`. `min` is inclusive, `max` is exclusive, and zero-volume boxes are
+invalid. A one-column vertical run therefore still uses `max.x = min.x + 1` and
+`max.z = min.z + 1`.
+
 Ownership note: these structs live in `freven_volumetric_api`. The world guest
 contract consumes them but does not own the volumetric topology or section
 layout semantics.

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -169,6 +169,10 @@ Current worldgen output family:
 - `WorldGenOutput.bootstrap.initial_world_spawn_hint`
 - `WorldTerrainWrite::{FillSection, FillBox, SetBlock}`
 
+`WorldTerrainWrite::FillBox` uses half-open absolute world-cell bounds:
+`[min, max)`. `min` is inclusive, `max` is exclusive, and zero-volume boxes are
+invalid.
+
 These volumetric structures live in `freven_volumetric_api` and are re-exported
 through the guest contract; the Wasm ABI keeps that ownership split intact.
 The bootstrap hint is advisory initial-world metadata; `feet_position` is the

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -270,6 +270,45 @@ initial world bootstrap feet-position hint rather than a generic respawn
 policy.
 
 
+
+### `WorldTerrainWrite::FillBox` bounds semantics
+
+`WorldTerrainWrite::FillBox` uses half-open bounds in absolute world-cell
+space: `[min, max)`.
+
+Example vertical run for one `(x, z)` column:
+
+```rust
+use freven_world_guest_sdk::{WorldCellPos, WorldTerrainWrite};
+
+let write = WorldTerrainWrite::FillBox {
+    min: WorldCellPos::new(x, start_y, z),
+    max: WorldCellPos::new(x + 1, end_y_exclusive, z + 1),
+    block_id,
+};
+```
+
+What this means:
+- `min` is inclusive
+- `max` is exclusive
+- `min == max` is invalid because it produces zero volume
+- minimum valid box extent is `1` on every axis
+- coordinates are absolute world-cell positions, not section-local offsets
+
+In practice:
+- use `SetBlock` for sparse or isolated cells
+- use `FillBox` for contiguous rectangular regions or vertical runs
+- use `FillSection` when one full section is uniform
+
+A vertical run at one `(x, z)` column therefore still needs:
+- `max.x = min.x + 1`
+- `max.z = min.z + 1`
+
+Do not treat `max` as an inclusive last block coordinate.
+If you have an inclusive end y from your own algorithm, convert it first to an
+exclusive bound before emitting `FillBox`.
+
+
 ### Initial world spawn hints for custom worldgen providers
 
 Custom worldgen providers may return an advisory initial bootstrap spawn hint

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -269,6 +269,53 @@ That includes `WorldGenOutput.bootstrap.initial_world_spawn_hint`, an advisory
 initial world bootstrap feet-position hint rather than a generic respawn
 policy.
 
+
+### Initial world spawn hints for custom worldgen providers
+
+Custom worldgen providers may return an advisory initial bootstrap spawn hint
+through `WorldGenOutput.bootstrap.initial_world_spawn_hint`.
+
+Example:
+
+```rust
+use freven_world_guest_sdk::{
+    InitialWorldSpawnHint,
+    WorldGenBootstrapOutput,
+    WorldGenOutput,
+};
+
+fn finish_worldgen(
+    writes: Vec<freven_world_guest_sdk::WorldTerrainWrite>,
+    surface_y: f32,
+) -> WorldGenOutput {
+    WorldGenOutput {
+        writes,
+        bootstrap: WorldGenBootstrapOutput {
+            initial_world_spawn_hint: Some(InitialWorldSpawnHint {
+                feet_position: [16.5, surface_y + 2.0, 16.5],
+            }),
+        },
+    }
+}
+```
+
+What this means:
+- this is for **initial world bootstrap** only, not general respawn policy
+- `feet_position` is a world-space **feet** position, not a collider center
+- the host resolves authoritative initial spawn and may validate or adjust the
+  final result against loaded terrain
+- current bootstrap flow explicitly probes the bootstrap worldgen column and
+  consumes the hint from that bootstrap bring-up path; later worldgen calls do
+  not redefine runtime spawn policy
+
+Recommended strategy:
+- return a natural safe candidate from your terrain generator, such as a known
+  walkable surface point with standing room
+- prefer a plausible gameplay spawn area rather than flattening terrain around
+  `(0, 0)` just to force safe spawning
+- treat the hint as advice to bootstrap resolution, not as a guarantee that the
+  exact returned feet position will be used unchanged
+
 Those surfaces are intentionally not available from the neutral
 `freven_guest_sdk` crate.
 


### PR DESCRIPTION
## Summary

Clarify the canonical bounds semantics and recommended usage of
`WorldTerrainWrite::FillBox`.

Part of #46.

## What changed

- document `WorldTerrainWrite::FillBox` directly on the canonical volumetric
  contract surface in `freven_volumetric_api`
- document that `FillBox` uses half-open absolute world-cell bounds: `[min, max)`
- document that zero-volume boxes are invalid and minimum valid extent is `1`
  on every axis
- document the one-column vertical-run shape (`max.x = min.x + 1`,
  `max.z = min.z + 1`)
- document recommended usage of `SetBlock` vs `FillBox` vs `FillSection`
- add matching author-facing guidance to:
  - `docs/WASM_AUTHORING.md`
  - `crates/freven_world_guest_sdk/README.md`
  - `docs/GUEST_CONTRACT_v1.md`
  - `docs/WASM_ABI_v1.md`

## Why

The runtime already enforced `FillBox` validity, but the public SDK/docs did not
make the bounds semantics obvious enough for worldgen authors.

This closes that gap by documenting the canonical contract where authors and
reference readers actually look, instead of leaving `FillBox` shape to
trial-and-error.

## Validation

- reviewed updated `freven_volumetric_api` doc comments
- reviewed updated author-facing worldgen docs
- reviewed updated contract/ABI reference docs
- verified the docs now explicitly cover:
  - half-open `[min, max)` semantics
  - invalid zero-volume boxes
  - minimum valid extents
  - vertical-run authoring shape
  - absolute world-cell coordinates
  - recommended `SetBlock` / `FillBox` / `FillSection` usage