### PR TITLE
Document mod config authoring path

### DIFF
--- a/crates/freven_world_guest_sdk/README.md
+++ b/crates/freven_world_guest_sdk/README.md
@@ -225,8 +225,12 @@ Recommended strategy:
 - Block/content registration stays on `BlockDescriptor` and `BlockRuntimeId`;
   raw section encodings are not the authoring contract.
 - Guest start callbacks receive `StartInput { session, experience_id, mod_id, config }`.
-  `StartInputExt::config_typed::<T>()` decodes the canonical per-mod TOML
-  config document for the guest path.
+  `StartInputExt::config_typed::<T>()` decodes the canonical final resolved
+  per-mod TOML config document. Schema/defaults are declared through
+  `config_schema = "config.schema.toml"` in `mod.toml`; active values are
+  authored through `[config."<mod_id>"]` in an experience or
+  `[layers.config."<mod_id>"]` in a stack layer. `mod.toml [config]` is not
+  active runtime config.
 - `StartInput.session` is the canonical runtime-session identity for that guest
   instance on one hosted side. Stateful guests should key long-lived state off
   that session identity instead of ad hoc process statics.

--- a/docs/EXTERNAL_MOD_IPC_v1.md
+++ b/docs/EXTERNAL_MOD_IPC_v1.md
@@ -85,8 +85,11 @@ through `freven_world_api`, but they do not use this IPC transport.
 
 ## Behavioral rules
 
-`StartInput` carries `session`, `experience_id`, `mod_id`, and the resolved
-per-mod config document (`ModConfigDocument`, currently TOML text).
+`StartInput` carries `session`, `experience_id`, `mod_id`, and the final
+resolved per-mod config document (`ModConfigDocument`, currently TOML text). The
+host computes it from schema defaults plus active experience/stack authored
+overrides; external guests must not treat `mod.toml [config]` as active runtime
+config.
 
 - Host enforces per-call timeout for handshake, negotiation, steady-state
   lifecycle calls, and action IPC.

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -141,9 +141,14 @@ Current hosting policy:
 - `mod_id`
 - `config`
 
-`config` is the resolved per-mod config document from `experience.config."<mod_id>"`.
-Contract v1 currently serializes that document as TOML text with an explicit
-`ModConfigFormat`.
+`config` is the final resolved per-mod config document for this mod. It is
+computed by the host from schema defaults plus active experience/stack authored
+overrides. Guests do not read `mod.toml`, `config.schema.toml`, experience files,
+or stack files directly.
+
+Contract v1 currently serializes the resolved document as TOML text with an
+explicit `ModConfigFormat`. See `MOD_CONFIG_v1.md` for the public authoring and
+resolution model.
 
 Runtime/config/experience metadata is carried where it is semantically stable:
 

--- a/docs/MOD_CONFIG_v1.md
+++ b/docs/MOD_CONFIG_v1.md
@@ -1,0 +1,201 @@
+# Mod Config v1
+
+This document defines the public Freven mod configuration authoring path.
+
+The core rule is simple:
+
+- `mod.toml` is manifest, execution, trust, surface, entrypoint, capability, and
+  schema-reference metadata.
+- `config.schema.toml` declares the mod's supported settings and defaults.
+- active runtime values are authored by the selected experience or experience
+  stack.
+- guests receive only the final resolved per-mod configuration through
+  `StartInput.config`.
+
+`mod.toml [config]` is intentionally not a supported runtime config path. Hosts,
+tools, and users should not treat it as active gameplay configuration.
+
+## Files and ownership
+
+A mod may reference a schema file from `mod.toml`:
+
+```toml
+schema = 3
+id = "example.hello"
+version = "0.1.0"
+artifact = "wasm_module"
+execution = "wasm_guest"
+trust = "sandboxed"
+policy = "safe_guest"
+surfaces = "server"
+entry = "mod.wasm"
+config_schema = "config.schema.toml"
+```
+
+`config_schema` is a safe relative path next to the mod manifest. It must not be
+absolute and must not escape with `..`.
+
+The schema file declares settings, defaults, validation constraints, scope,
+reload policy, and authority:
+
+```toml
+schema = 1
+
+[[settings]]
+key = "enabled"
+type = "bool"
+default = true
+scope = "server_world"
+reload = "runtime"
+authority = "server"
+
+[[settings]]
+key = "max_mutations_per_tick"
+type = "int"
+default = 128
+min = 1
+max = 4096
+scope = "server_world"
+reload = "world_restart"
+authority = "server"
+
+[[settings]]
+key = "gravity"
+type = "float"
+default = 9.8
+min = 0.0
+max = 20.0
+scope = "server_world"
+reload = "world_restart"
+authority = "server"
+
+[[settings]]
+key = "difficulty"
+type = "enum"
+default = "normal"
+allowed_values = ["easy", "normal", "hard"]
+scope = "server_world"
+reload = "world_restart"
+authority = "server"
+```
+
+Supported setting types are `bool`, `int`, `float`, `string`, and `enum`.
+Supported scopes are `startup`, `server_world`, and `client_user`.
+Supported reload policies are `restart`, `world_restart`, `reconnect`, and
+`runtime`.
+Supported authorities are `server`, `client`, and `user`.
+
+The schema is a declaration and default source. It is not the user's active
+configuration file.
+
+## Active config in an experience
+
+An experience authors active values with a table per mod id:
+
+```toml
+[[mods]]
+id = "example.hello"
+version = "^0.1"
+
+[config."example.hello"]
+enabled = true
+max_mutations_per_tick = 256
+gravity = 8.5
+difficulty = "hard"
+```
+
+For mods with a schema, the resolver starts from schema defaults and applies the
+authored values. Unknown keys, invalid value types, invalid enum values, and
+out-of-bounds numeric values are rejected before runtime start.
+
+For mods without a schema, the authored per-mod table is preserved as-is. This
+keeps early/custom mods usable while schema-backed mods get validation and
+tooling support.
+
+## Active config in an experience stack
+
+A stack layer can override the base experience config:
+
+```toml
+[[layers]]
+id = "example.stack.layer"
+title = "Server Balance"
+
+[layers.config."example.hello"]
+max_mutations_per_tick = 512
+difficulty = "normal"
+```
+
+Stack layer config deep-merges over the base experience config. If both sides
+contain tables, nested keys are merged recursively. Otherwise the layer value
+replaces the base value.
+
+Current public authored layers are experience config and stack-layer config.
+Future world or instance config layers should compose into the same resolved
+effective per-mod config model rather than adding a separate guest-facing side
+channel.
+
+## Guest access
+
+Guests do not read `mod.toml`, `config.schema.toml`, the experience file, or the
+stack file directly. The host resolves the final effective config and sends it
+in `StartInput.config`.
+
+With `freven_world_guest_sdk`:
+
+```rust
+use serde::Deserialize;
+use freven_world_guest_sdk::{LifecycleResult, StartInput, StartInputExt};
+
+#[derive(Debug, Deserialize)]
+struct Config {
+    enabled: bool,
+    max_mutations_per_tick: u32,
+    gravity: f32,
+    difficulty: String,
+}
+
+fn start_server(input: &StartInput) -> LifecycleResult {
+    let config: Config = input
+        .config_typed()
+        .expect("resolved config should match the declared schema");
+
+    if config.enabled {
+        freven_world_guest_sdk::log_info!(
+            "difficulty={} gravity={}",
+            config.difficulty,
+            config.gravity
+        );
+    }
+
+    LifecycleResult::default()
+}
+```
+
+`StartInput.config` is currently serialized as TOML text inside
+`ModConfigDocument`. The transport shape is an implementation detail of the
+guest contract; semantically, it is the final resolved per-mod config.
+
+## Verification
+
+DevKit users can inspect the resolved config before starting a runtime:
+
+```bash
+freven_boot config explain --instance <instance> --experience <experience_id>
+freven_boot config explain --instance <instance> --experience <experience_id> --mod example.hello
+```
+
+This command resolves the selected experience/stack and prints the same effective
+per-mod config that guests receive at start.
+
+## Reload and compatibility notes
+
+`reload` is public metadata for tooling and host policy. A setting marked
+`runtime` may be safe to apply while running, while `world_restart`, `reconnect`,
+or `restart` indicates a stronger lifecycle boundary. Existing worlds or already
+running servers may still need a restart or recreation depending on what the mod
+does with the setting.
+
+Do not add ad hoc config channels for a specific transport. Wasm, native,
+external-process, and builtin/compile-time authoring should all converge on the
+same resolved effective config semantics.

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -91,8 +91,10 @@ Returned bytes are postcard-encoded `freven_world_guest` contract types:
 - `freven_guest_on_server_messages` takes `ServerMessageInput` and returns `ServerMessageResult`
 - lifecycle exports take `StartInput` or `TickInput` and return `LifecycleResult`
 
-`StartInput` carries `experience_id`, `mod_id`, and the resolved per-mod config
-document (`ModConfigDocument`, currently TOML text).
+`StartInput` carries `experience_id`, `mod_id`, and the final resolved per-mod
+config document (`ModConfigDocument`, currently TOML text). The host computes it
+from schema defaults plus active experience/stack authored overrides; native
+guests must not treat `mod.toml [config]` as active runtime config.
 
 `ActionInput` carries `binding_id`, `player_id`, `level_id`, `stream_epoch`,
 `action_seq`, `at_input_seq`, and opaque payload bytes. Those fields inside the

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ Read them in this order:
   neutral runtime-loaded guest semantics
 - [GUEST_CONTRACT_v1.md](GUEST_CONTRACT_v1.md): canonical world-owned
   runtime-loaded guest semantics
+- [MOD_CONFIG_v1.md](MOD_CONFIG_v1.md): public mod config schema,
+  experience/stack authoring, resolution, and guest delivery semantics
 - [WORLDGEN_PROVIDER_CONCURRENCY_v1.md](WORLDGEN_PROVIDER_CONCURRENCY_v1.md):
   canonical worldgen provider concurrency contract; current mode is
   `serial_session`

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -122,6 +122,12 @@ Host behavior:
 - `format: ModConfigFormat` (`toml`)
 - `text: String`
 
+`ModConfigDocument` carries the final resolved per-mod config. The host
+computes it from schema defaults plus active experience/stack authored overrides.
+Wasm guests must treat `StartInput.config` as the only runtime config input.
+`mod.toml [config]` is not a supported active config path. See
+`MOD_CONFIG_v1.md` for authoring details.
+
 Lifecycle now uses the same canonical runtime-output model as actions and
 message callbacks through `LifecycleResult.output`.
 

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -157,13 +157,9 @@ id = "example.hello"
 version = "^0.1"
 ```
 
-Runtime config belongs in the active experience:
-
-```toml
-[config."example.hello"]
-greeting = "hello"
-tick_every = 1
-```
+Runtime config belongs to the active experience or experience stack, not
+`mod.toml`. See [MOD_CONFIG_v1.md](MOD_CONFIG_v1.md) for the canonical schema,
+override, validation, and guest delivery model.
 
 ### Bundled product-owned mod inside an experience
 
@@ -188,10 +184,119 @@ path = "mods/example.standalone.shell.core/mod.toml"
 
 Notes:
 - `mod.toml` is the manifest / capability-request surface, not the active runtime config document.
-- Guest `StartInput.config` comes from `experience.config."<mod_id>"`.
+- `mod.toml [config]` is not a supported runtime config path.
+- `config_schema = "config.schema.toml"` declares schema/defaults for tooling and validation.
+- Active values come from `[config."<mod_id>"]` in an experience or `[layers.config."<mod_id>"]` in a stack layer.
+- Guest `StartInput.config` is the final resolved per-mod config after schema defaults and authored overrides.
 - Declare `[capabilities]` only when you need non-default limits or worldgen-specific budgets.
 - Use `surfaces = "server"` for server-only mods.
   Use `surfaces = "both"` only when the guest is meant to attach on both sides.
+
+## Runtime config
+
+The supported runtime config path is documented in
+[MOD_CONFIG_v1.md](MOD_CONFIG_v1.md).
+
+Minimal schema-backed mod layout:
+
+```text
+mods/example.hello/
+  mod.toml
+  config.schema.toml
+  mod.wasm
+```
+
+`mod.toml` references the schema file:
+
+```toml
+config_schema = "config.schema.toml"
+```
+
+`config.schema.toml` declares defaults and validation:
+
+```toml
+schema = 1
+
+[[settings]]
+key = "enabled"
+type = "bool"
+default = true
+scope = "server_world"
+reload = "runtime"
+authority = "server"
+
+[[settings]]
+key = "max_mutations_per_tick"
+type = "int"
+default = 128
+min = 1
+max = 4096
+scope = "server_world"
+reload = "world_restart"
+authority = "server"
+
+[[settings]]
+key = "gravity"
+type = "float"
+default = 9.8
+min = 0.0
+max = 20.0
+scope = "server_world"
+reload = "world_restart"
+authority = "server"
+
+[[settings]]
+key = "difficulty"
+type = "enum"
+default = "normal"
+allowed_values = ["easy", "normal", "hard"]
+scope = "server_world"
+reload = "world_restart"
+authority = "server"
+```
+
+An experience authors active values:
+
+```toml
+[config."example.hello"]
+enabled = true
+max_mutations_per_tick = 256
+gravity = 8.5
+difficulty = "hard"
+```
+
+A stack layer can override them:
+
+```toml
+[layers.config."example.hello"]
+difficulty = "normal"
+```
+
+Guests read only the resolved final config:
+
+```rust
+use serde::Deserialize;
+use freven_world_guest_sdk::{StartInput, StartInputExt};
+
+#[derive(Deserialize)]
+struct Config {
+    enabled: bool,
+    max_mutations_per_tick: u32,
+    gravity: f32,
+    difficulty: String,
+}
+
+fn start_server(input: &StartInput) {
+    let config: Config = input.config_typed().expect("valid resolved config");
+    let _ = config;
+}
+```
+
+For local verification, use:
+
+```bash
+freven_boot config explain --instance <instance> --experience <experience_id> --mod example.hello
+```
 
 ## Capability requests
 


### PR DESCRIPTION
## Summary

Document the supported Freven mod config path now that the SDK schema model, engine resolver, and boot diagnostics are in place.

This adds `MOD_CONFIG_v1.md` as the canonical public authoring reference and updates guest/transport docs to make the runtime config boundary explicit.

## What changed

- document `config_schema = "config.schema.toml"` as the schema/default declaration path
- document active config authoring through `[config."<mod_id>"]` and `[layers.config."<mod_id>"]`
- clarify that `mod.toml [config]` is not active runtime config
- clarify that guests receive only final resolved config through `StartInput.config`
- point Wasm/native/external/guest docs at the canonical config reference
- mention `freven_boot config explain` as the verification path

## Validation

- git --no-pager diff --cached --check