### PR TITLE
Define gameplay state SDK contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "freven_gameplay_state_guest"
+version = "0.1.0"
+dependencies = [
+ "freven_gameplay_state_sdk_types",
+ "postcard",
+ "serde",
+]
+
+[[package]]
+name = "freven_gameplay_state_sdk_types"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "freven_guest"
 version = "0.1.0"
 dependencies = [
@@ -151,6 +167,8 @@ version = "0.1.0"
 dependencies = [
  "freven_block_guest",
  "freven_block_sdk_types",
+ "freven_gameplay_state_guest",
+ "freven_gameplay_state_sdk_types",
  "freven_guest",
  "freven_sdk_types",
  "freven_volumetric_api",
@@ -186,15 +204,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -235,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -287,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -327,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -342,27 +360,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"
@@ -372,9 +390,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ freven_volumetric_sdk_types = { path = "crates/freven_volumetric_sdk_types", ver
 freven_block_sdk_types = { path = "crates/freven_block_sdk_types", version = "0.1.0" }
 freven_block_guest = { path = "crates/freven_block_guest", version = "0.1.0" }
 freven_block_api = { path = "crates/freven_block_api", version = "0.1.0" }
+freven_gameplay_state_sdk_types = { path = "crates/freven_gameplay_state_sdk_types", version = "0.1.0" }
+freven_gameplay_state_guest = { path = "crates/freven_gameplay_state_guest", version = "0.1.0" }
+freven_gameplay_state_api = { path = "crates/freven_gameplay_state_api", version = "0.1.0" }
 postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.228", features = ["derive"] }
 toml = "1.0.6"

--- a/crates/freven_gameplay_state_api/Cargo.toml
+++ b/crates/freven_gameplay_state_api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "freven_gameplay_state_api"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "Builtin gameplay-state authority traits for Freven."
+publish = false
+
+[dependencies]
+freven_gameplay_state_sdk_types.workspace = true
+freven_gameplay_state_guest.workspace = true

--- a/crates/freven_gameplay_state_api/src/lib.rs
+++ b/crates/freven_gameplay_state_api/src/lib.rs
@@ -1,0 +1,50 @@
+//! Compile-time / builtin-facing gameplay-state authority contracts.
+//!
+//! Ownership:
+//! - identity/value vocabulary lives in `freven_gameplay_state_sdk_types`
+//! - runtime-loaded mutation/query shapes live in `freven_gameplay_state_guest`
+//! - builtin/compile-time authority and view traits live here
+
+use freven_gameplay_state_guest::GameplayStateMutation;
+use freven_gameplay_state_sdk_types::{
+    GameplayStateKey, GameplayStatePolicy, GameplayStateValue,
+};
+
+pub trait GameplayStateView {
+    fn gameplay_state(&self, key: &GameplayStateKey) -> Option<GameplayStateValue>;
+
+    fn contains_gameplay_state(&self, key: &GameplayStateKey) -> bool {
+        self.gameplay_state(key).is_some()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GameplayStateMutationResult {
+    Applied,
+    Deleted,
+    Missing,
+    UnsupportedOwner,
+    UnsupportedPolicy,
+    Rejected { message: String },
+}
+
+pub trait GameplayStateAuthority: GameplayStateView {
+    fn try_apply_gameplay_state(
+        &mut self,
+        mutation: &GameplayStateMutation,
+    ) -> GameplayStateMutationResult;
+
+    fn set_gameplay_state(
+        &mut self,
+        key: GameplayStateKey,
+        value: GameplayStateValue,
+        policy: GameplayStatePolicy,
+    ) -> GameplayStateMutationResult {
+        self.try_apply_gameplay_state(&GameplayStateMutation::Set { key, value, policy })
+    }
+
+    fn delete_gameplay_state(&mut self, key: GameplayStateKey) -> GameplayStateMutationResult {
+        self.try_apply_gameplay_state(&GameplayStateMutation::Delete { key })
+    }
+}

--- a/crates/freven_gameplay_state_guest/Cargo.toml
+++ b/crates/freven_gameplay_state_guest/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "freven_gameplay_state_guest"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "Runtime-loaded gameplay-state contract for Freven."
+publish = false
+
+[dependencies]
+freven_gameplay_state_sdk_types.workspace = true
+serde.workspace = true
+
+[dev-dependencies]
+postcard.workspace = true

--- a/crates/freven_gameplay_state_guest/src/lib.rs
+++ b/crates/freven_gameplay_state_guest/src/lib.rs
@@ -1,0 +1,125 @@
+//! Canonical public runtime-loaded gameplay-state contract.
+//!
+//! Ownership:
+//! - identity/value vocabulary lives in `freven_gameplay_state_sdk_types`
+//! - runtime-loaded gameplay-state query/mutation shapes live here
+//!
+//! This crate does not define Vanilla inventory semantics. It only defines the
+//! generic runtime-facing carrier family that hosts can authorize and apply.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use freven_gameplay_state_sdk_types::{GameplayStateKey, GameplayStatePolicy, GameplayStateValue};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct GameplayStateMutationBatch {
+    pub mutations: Vec<GameplayStateMutation>,
+}
+
+impl GameplayStateMutationBatch {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.mutations.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum GameplayStateMutation {
+    Set {
+        key: GameplayStateKey,
+        value: GameplayStateValue,
+        policy: GameplayStatePolicy,
+    },
+    Delete {
+        key: GameplayStateKey,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum GameplayStateQueryRequest {
+    Get { key: GameplayStateKey },
+    Exists { key: GameplayStateKey },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum GameplayStateQueryResponse {
+    Get(Option<GameplayStateValue>),
+    Exists(bool),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum GameplayStateServiceRequest {
+    Query(GameplayStateQueryRequest),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum GameplayStateServiceResponse {
+    Query(GameplayStateQueryResponse),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use freven_gameplay_state_sdk_types::{GameplayStateCodec, GameplayStateOwner};
+
+    fn postcard_roundtrip<T>(value: &T) -> T
+    where
+        T: Clone + PartialEq + core::fmt::Debug + serde::Serialize + serde::de::DeserializeOwned,
+    {
+        let bytes = postcard::to_allocvec(value).expect("postcard encode");
+        let decoded = postcard::from_bytes(&bytes).expect("postcard decode");
+        assert_eq!(decoded, *value);
+        decoded
+    }
+
+    #[test]
+    fn mutation_batch_empty_matches_payload_state() {
+        let key = GameplayStateKey::new(
+            GameplayStateOwner::Player { player_id: 1 },
+            "example.mod",
+            "loadout",
+        )
+        .expect("valid key");
+
+        let mut batch = GameplayStateMutationBatch::default();
+        assert!(batch.is_empty());
+
+        batch.mutations.push(GameplayStateMutation::Set {
+            key,
+            value: GameplayStateValue::new(1, GameplayStateCodec::OpaqueBytes, [1, 2, 3])
+                .expect("valid value"),
+            policy: GameplayStatePolicy::default(),
+        });
+
+        assert!(!batch.is_empty());
+        postcard_roundtrip(&batch);
+    }
+
+    #[test]
+    fn query_request_roundtrips() {
+        let key = GameplayStateKey::new(
+            GameplayStateOwner::Player { player_id: 9 },
+            "freven.vanilla",
+            "selected_slot",
+        )
+        .expect("valid key");
+
+        postcard_roundtrip(&GameplayStateServiceRequest::Query(
+            GameplayStateQueryRequest::Get { key },
+        ));
+    }
+}

--- a/crates/freven_gameplay_state_sdk_types/Cargo.toml
+++ b/crates/freven_gameplay_state_sdk_types/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "freven_gameplay_state_sdk_types"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "Stable gameplay-state SDK data contracts for Freven."
+publish = false
+
+[dependencies]
+serde.workspace = true

--- a/crates/freven_gameplay_state_sdk_types/src/lib.rs
+++ b/crates/freven_gameplay_state_sdk_types/src/lib.rs
@@ -1,0 +1,354 @@
+//! Public gameplay-state identity and value contracts for Freven.
+//!
+//! Ownership:
+//! - stable gameplay-state owner/scope identity
+//! - namespaced state keys
+//! - opaque/versioned state values
+//! - public persistence and replication policy vocabulary
+//!
+//! Non-responsibilities:
+//! - runtime storage implementation
+//! - save/load lifecycle implementation
+//! - network replication implementation
+//! - Vanilla inventory/hotbar semantics
+//! - block/entity actor lifecycle semantics
+//!
+//! This crate defines the reusable public vocabulary. Gameplay layers own the
+//! schema and meaning of their state values. Engine/runtime layers own authority,
+//! isolation, lifecycle, limits, diagnostics, persistence, and replication policy.
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
+
+use serde::{Deserialize, Serialize};
+
+pub const MAX_GAMEPLAY_STATE_NAMESPACE_LEN: usize = 128;
+pub const MAX_GAMEPLAY_STATE_KEY_LEN: usize = 128;
+pub const MAX_GAMEPLAY_STATE_CODEC_LEN: usize = 64;
+pub const MAX_GAMEPLAY_STATE_OBJECT_ID_LEN: usize = 256;
+pub const DEFAULT_MAX_GAMEPLAY_STATE_VALUE_BYTES: usize = 64 * 1024;
+
+/// Stable owner/scope identity for gameplay state.
+///
+/// This is intentionally broader than Vanilla inventory or blocks. The engine
+/// may support only a subset in a given phase, but the public identity model is
+/// shaped so later player/entity/world/object state can share one vocabulary.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum GameplayStateOwner {
+    Player {
+        player_id: u64,
+    },
+    Entity {
+        entity_id: u64,
+    },
+    World {
+        world_id: String,
+    },
+    Level {
+        level_id: u32,
+    },
+    WorldPosition {
+        level_id: u32,
+        pos: (i32, i32, i32),
+    },
+    Chunk {
+        level_id: u32,
+        cx: i32,
+        cz: i32,
+    },
+    Object {
+        namespace: String,
+        object_id: String,
+    },
+}
+
+/// Fully qualified gameplay-state key.
+///
+/// `namespace` identifies the gameplay/mod owner, for example
+/// `freven.vanilla` or `example.mod`.
+///
+/// `key` identifies the state inside that namespace, for example
+/// `selected_slot`, `hotbar`, `mask_filter`, or `weapon_loadout`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GameplayStateKey {
+    pub owner: GameplayStateOwner,
+    pub namespace: String,
+    pub key: String,
+}
+
+impl GameplayStateKey {
+    pub fn new(
+        owner: GameplayStateOwner,
+        namespace: impl Into<String>,
+        key: impl Into<String>,
+    ) -> Result<Self, GameplayStateValidationError> {
+        let value = Self {
+            owner,
+            namespace: namespace.into(),
+            key: key.into(),
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    pub fn validate(&self) -> Result<(), GameplayStateValidationError> {
+        validate_identifier(
+            "namespace",
+            &self.namespace,
+            MAX_GAMEPLAY_STATE_NAMESPACE_LEN,
+        )?;
+        validate_identifier("key", &self.key, MAX_GAMEPLAY_STATE_KEY_LEN)?;
+        self.owner.validate()
+    }
+}
+
+impl GameplayStateOwner {
+    pub fn validate(&self) -> Result<(), GameplayStateValidationError> {
+        match self {
+            Self::Object {
+                namespace,
+                object_id,
+            } => {
+                validate_identifier(
+                    "object_namespace",
+                    namespace,
+                    MAX_GAMEPLAY_STATE_NAMESPACE_LEN,
+                )?;
+                validate_non_empty_bounded("object_id", object_id, MAX_GAMEPLAY_STATE_OBJECT_ID_LEN)
+            }
+            Self::World { world_id } => {
+                validate_non_empty_bounded("world_id", world_id, MAX_GAMEPLAY_STATE_OBJECT_ID_LEN)
+            }
+            Self::Player { .. }
+            | Self::Entity { .. }
+            | Self::Level { .. }
+            | Self::WorldPosition { .. }
+            | Self::Chunk { .. } => Ok(()),
+        }
+    }
+}
+
+/// Payload codec marker for an opaque gameplay-state value.
+///
+/// The engine does not interpret gameplay semantics. The marker is for
+/// diagnostics, migration, and tooling.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum GameplayStateCodec {
+    #[default]
+    OpaqueBytes,
+    Postcard,
+    Json,
+    Custom(String),
+}
+
+impl GameplayStateCodec {
+    pub fn validate(&self) -> Result<(), GameplayStateValidationError> {
+        match self {
+            Self::Custom(codec) => {
+                validate_identifier("codec", codec, MAX_GAMEPLAY_STATE_CODEC_LEN)
+            }
+            Self::OpaqueBytes | Self::Postcard | Self::Json => Ok(()),
+        }
+    }
+}
+
+/// Opaque/versioned gameplay-state value.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GameplayStateValue {
+    pub version: u32,
+    pub codec: GameplayStateCodec,
+    pub bytes: Vec<u8>,
+}
+
+impl GameplayStateValue {
+    pub fn new(
+        version: u32,
+        codec: GameplayStateCodec,
+        bytes: impl Into<Vec<u8>>,
+    ) -> Result<Self, GameplayStateValidationError> {
+        let value = Self {
+            version,
+            codec,
+            bytes: bytes.into(),
+        };
+        value.validate(DEFAULT_MAX_GAMEPLAY_STATE_VALUE_BYTES)?;
+        Ok(value)
+    }
+
+    pub fn validate(&self, max_bytes: usize) -> Result<(), GameplayStateValidationError> {
+        self.codec.validate()?;
+        if self.bytes.len() > max_bytes {
+            return Err(GameplayStateValidationError::ValueTooLarge {
+                len: self.bytes.len(),
+                max: max_bytes,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Persistence policy requested for a gameplay-state value.
+///
+/// Engine/runtime support may initially accept only `Transient`; the public
+/// vocabulary is intentionally wider so later persistence work does not need a
+/// new identity model.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum GameplayStatePersistencePolicy {
+    #[default]
+    Transient,
+    PlayerProfile,
+    WorldSave,
+    InstanceSave,
+}
+
+/// Replication policy requested for a gameplay-state value.
+///
+/// `ServerOnly` is the safest default. More visible policies require explicit
+/// host/runtime support.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum GameplayStateReplicationPolicy {
+    #[default]
+    ServerOnly,
+    OwningClient,
+    Observers,
+    Public,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GameplayStatePolicy {
+    pub persistence: GameplayStatePersistencePolicy,
+    pub replication: GameplayStateReplicationPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GameplayStateValidationError {
+    EmptyField {
+        field: &'static str,
+    },
+    FieldTooLong {
+        field: &'static str,
+        len: usize,
+        max: usize,
+    },
+    InvalidIdentifierChar {
+        field: &'static str,
+        ch: char,
+    },
+    ValueTooLarge {
+        len: usize,
+        max: usize,
+    },
+}
+
+impl core::fmt::Display for GameplayStateValidationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::EmptyField { field } => write!(f, "{field} must not be empty"),
+            Self::FieldTooLong { field, len, max } => {
+                write!(f, "{field} length {len} exceeds maximum {max}")
+            }
+            Self::InvalidIdentifierChar { field, ch } => {
+                write!(f, "{field} contains invalid character {ch:?}")
+            }
+            Self::ValueTooLarge { len, max } => {
+                write!(f, "gameplay-state value length {len} exceeds maximum {max}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GameplayStateValidationError {}
+
+fn validate_non_empty_bounded(
+    field: &'static str,
+    value: &str,
+    max: usize,
+) -> Result<(), GameplayStateValidationError> {
+    if value.is_empty() {
+        return Err(GameplayStateValidationError::EmptyField { field });
+    }
+    if value.len() > max {
+        return Err(GameplayStateValidationError::FieldTooLong {
+            field,
+            len: value.len(),
+            max,
+        });
+    }
+    Ok(())
+}
+
+fn validate_identifier(
+    field: &'static str,
+    value: &str,
+    max: usize,
+) -> Result<(), GameplayStateValidationError> {
+    validate_non_empty_bounded(field, value, max)?;
+    for ch in value.chars() {
+        if !(ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '_' | '-' | '.')) {
+            return Err(GameplayStateValidationError::InvalidIdentifierChar { field, ch });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gameplay_state_key_accepts_mod_namespace_and_state_key() {
+        let key = GameplayStateKey::new(
+            GameplayStateOwner::Player { player_id: 7 },
+            "freven.vanilla",
+            "selected_slot",
+        )
+        .expect("valid key");
+
+        assert_eq!(key.namespace, "freven.vanilla");
+        assert_eq!(key.key, "selected_slot");
+    }
+
+    #[test]
+    fn gameplay_state_key_rejects_invalid_namespace() {
+        let err = GameplayStateKey::new(
+            GameplayStateOwner::Player { player_id: 7 },
+            "Freven.Vanilla",
+            "selected_slot",
+        )
+        .expect_err("uppercase namespace should be rejected");
+
+        assert!(matches!(
+            err,
+            GameplayStateValidationError::InvalidIdentifierChar {
+                field: "namespace",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn gameplay_state_value_enforces_size_limit() {
+        let value = GameplayStateValue {
+            version: 1,
+            codec: GameplayStateCodec::OpaqueBytes,
+            bytes: vec![0; 4],
+        };
+
+        assert_eq!(
+            value.validate(3),
+            Err(GameplayStateValidationError::ValueTooLarge { len: 4, max: 3 })
+        );
+    }
+}

--- a/crates/freven_world_guest/Cargo.toml
+++ b/crates/freven_world_guest/Cargo.toml
@@ -12,6 +12,8 @@ freven_sdk_types.workspace = true
 freven_world_sdk_types.workspace = true
 freven_block_sdk_types.workspace = true
 freven_block_guest.workspace = true
+freven_gameplay_state_sdk_types.workspace = true
+freven_gameplay_state_guest.workspace = true
 serde.workspace = true
 freven_volumetric_api.workspace = true
 

--- a/crates/freven_world_guest/src/lib.rs
+++ b/crates/freven_world_guest/src/lib.rs
@@ -8,6 +8,7 @@
 //! - generic guest/runtime transport semantics live in `freven_guest`
 //! - volumetric topology/addressing live in `freven_volumetric_sdk_types`
 //! - standard block/profile vocabulary lives in `freven_block_sdk_types`
+//! - gameplay-state identity/value vocabulary lives in `freven_gameplay_state_sdk_types`
 //! - this crate defines the canonical runtime-loaded world guest contract that
 //!   consumes those lower-layer vocabularies
 //!
@@ -15,16 +16,19 @@
 //! - block/profile vocabulary is owned by `freven_block_sdk_types`
 //! - runtime-loaded block mutation/query/service contracts are owned by
 //!   `freven_block_guest`
-//! - this crate may still carry block-owned families inside the generic
-//!   world guest/runtime envelope
+//! - this crate may still carry block-owned and gameplay-state-owned families
+//!   inside the generic world guest/runtime envelope
 //! - that carrier role does not make `freven_world_guest` the owner of
-//!   block gameplay semantics
+//!   block gameplay or gameplay-state semantics
 
 extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
 use freven_block_guest::{BlockMutationBatch, BlockServiceRequest, BlockServiceResponse};
 use freven_block_sdk_types::BlockDescriptor;
+use freven_gameplay_state_guest::{
+    GameplayStateMutationBatch, GameplayStateServiceRequest, GameplayStateServiceResponse,
+};
 use freven_guest::{
     CapabilityDeclaration, ChannelDeclaration, ComponentDeclaration, LifecycleHooks, LogPayload,
     MessageDeclaration, MessageHooks, RuntimeSessionInfo,
@@ -316,12 +320,13 @@ pub enum ActionOutcome {
 pub struct RuntimeOutput {
     pub messages: RuntimeMessageOutput,
     pub blocks: BlockMutationBatch,
+    pub gameplay_state: GameplayStateMutationBatch,
 }
 
 impl RuntimeOutput {
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.messages.is_empty() && self.blocks.is_empty()
+        self.messages.is_empty() && self.blocks.is_empty() && self.gameplay_state.is_empty()
     }
 }
 
@@ -741,6 +746,7 @@ pub enum RuntimeObservabilityRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum WorldServiceRequest {
     Block(BlockServiceRequest),
+    GameplayState(GameplayStateServiceRequest),
     Query(WorldQueryRequest),
     ClientVisibility(ClientVisibilityRequest),
     Session(WorldSessionRequest),
@@ -752,6 +758,7 @@ pub enum WorldServiceRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum WorldServiceResponse {
     Block(BlockServiceResponse),
+    GameplayState(GameplayStateServiceResponse),
     Query(WorldQueryResponse),
     ClientVisibility(ClientVisibilityResponse),
     Session(WorldSessionResponse),
@@ -767,7 +774,16 @@ pub enum WorldServiceResponse {
 #[cfg(test)]
 mod tests {
     use super::{
-        ClientKeyCode, ClientMouseButton, RuntimeClientControlRequest, WorldServiceRequest,
+        ClientKeyCode, ClientMouseButton, RuntimeClientControlRequest, RuntimeOutput,
+        WorldServiceRequest,
+    };
+    use freven_gameplay_state_guest::{
+        GameplayStateMutation, GameplayStateMutationBatch, GameplayStateQueryRequest,
+        GameplayStateServiceRequest,
+    };
+    use freven_gameplay_state_sdk_types::{
+        GameplayStateCodec, GameplayStateKey, GameplayStateOwner, GameplayStatePolicy,
+        GameplayStateValue,
     };
 
     fn postcard_roundtrip<T>(value: &T) -> T
@@ -824,6 +840,47 @@ mod tests {
             assert_eq!(decoded, key);
             postcard_roundtrip(&key);
         }
+    }
+
+    #[test]
+    fn runtime_output_empty_tracks_gameplay_state_family() {
+        let key = GameplayStateKey::new(
+            GameplayStateOwner::Player { player_id: 1 },
+            "example.mod",
+            "loadout",
+        )
+        .expect("valid key");
+
+        let mut output = RuntimeOutput::default();
+        assert!(output.is_empty());
+
+        output.gameplay_state = GameplayStateMutationBatch {
+            mutations: vec![GameplayStateMutation::Set {
+                key,
+                value: GameplayStateValue::new(1, GameplayStateCodec::OpaqueBytes, [1, 2, 3])
+                    .expect("valid value"),
+                policy: GameplayStatePolicy::default(),
+            }],
+        };
+
+        assert!(!output.is_empty());
+        postcard_roundtrip(&output);
+    }
+
+    #[test]
+    fn gameplay_state_service_request_roundtrips_through_world_envelope() {
+        let key = GameplayStateKey::new(
+            GameplayStateOwner::Player { player_id: 7 },
+            "freven.vanilla",
+            "selected_slot",
+        )
+        .expect("valid key");
+
+        let request = WorldServiceRequest::GameplayState(GameplayStateServiceRequest::Query(
+            GameplayStateQueryRequest::Get { key },
+        ));
+
+        postcard_roundtrip(&request);
     }
 
     #[test]

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -175,6 +175,7 @@ generic world runtime-service envelope:
 - `WorldServiceRequest::Observability(...)`
 - `RuntimeOutput.messages`
 - `RuntimeOutput.blocks`
+- `RuntimeOutput.gameplay_state`
 
 Ownership inside that model is explicit:
 
@@ -182,10 +183,12 @@ Ownership inside that model is explicit:
   envelopes
 - `freven_block_guest` owns block mutation/query/service payload shapes
 - `WorldServiceRequest::Block(...)` / `WorldServiceResponse::Block(...)` and
-  `RuntimeOutput.blocks` are carrier/composition points for those block-owned
+  `RuntimeOutput.blocks` are carrier/composition points for block-owned families
+- `WorldServiceRequest::GameplayState(...)` / `WorldServiceResponse::GameplayState(...)`
+  and `RuntimeOutput.gameplay_state` are carrier/composition points for gameplay-state-owned
   families
 - that carrier role does not make `freven_world_guest` the owner of block
-  gameplay semantics
+  gameplay or gameplay-state semantics
 
 Current query/session/visibility requests include:
 
@@ -252,6 +255,13 @@ Current block-mutation family carried by runtime output includes:
 - `RuntimeOutput.blocks`
 - `BlockMutationBatch.mutations`
 - `BlockMutation::SetBlock { pos, block_id, expected_old }`
+
+Current gameplay-state mutation family carried by runtime output includes:
+
+- `RuntimeOutput.gameplay_state`
+- `GameplayStateMutationBatch.mutations`
+- `GameplayStateMutation::Set { key, value, policy }`
+- `GameplayStateMutation::Delete { key }`
 
 Current worldgen output family uses:
 

--- a/docs/NATIVE_MOD_ABI_v1.md
+++ b/docs/NATIVE_MOD_ABI_v1.md
@@ -134,8 +134,8 @@ Native guests can issue canonical runtime service requests through the installed
 
 - requests use `WorldServiceRequest`
 - responses use `WorldServiceResponse`
-- runtime output still flows separately through `RuntimeOutput.messages` and
-  `RuntimeOutput.blocks`
+- runtime output still flows separately through `RuntimeOutput.messages`,
+  `RuntimeOutput.blocks`, and `RuntimeOutput.gameplay_state`
 
 Ownership inside that model is explicit:
 
@@ -143,7 +143,9 @@ Ownership inside that model is explicit:
   envelopes
 - `freven_block_guest` owns block mutation/query/service payload shapes
 - `WorldServiceRequest::Block(...)` / `WorldServiceResponse::Block(...)` and
-  `RuntimeOutput.blocks` are carrier/composition points for those block-owned
+  `RuntimeOutput.blocks` are carrier/composition points for block-owned families
+- `WorldServiceRequest::GameplayState(...)` / `WorldServiceResponse::GameplayState(...)`
+  and `RuntimeOutput.gameplay_state` are carrier/composition points for gameplay-state-owned
   families
 
 The bridge is transport plumbing only. It must not redefine the semantic

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -174,11 +174,20 @@ Current block-mutation family carried by `RuntimeOutput`:
 - `BlockMutationBatch.mutations`
 - `BlockMutation::SetBlock { pos, block_id, expected_old }`
 
+Current gameplay-state mutation family carried by `RuntimeOutput`:
+
+- `RuntimeOutput.gameplay_state`
+- `GameplayStateMutationBatch.mutations`
+- `GameplayStateMutation::Set { key, value, policy }`
+- `GameplayStateMutation::Delete { key }`
+
 Ownership note:
 
 - `RuntimeOutput` is part of the generic `freven_world_guest` contract
 - the payload shape carried in `RuntimeOutput.blocks` is owned by
   `freven_block_guest`
+- the payload shape carried in `RuntimeOutput.gameplay_state` is owned by
+  `freven_gameplay_state_guest`
 - this transport mapping must preserve that ownership split rather than blur it
 
 Current worldgen output family:


### PR DESCRIPTION
## Summary

Part of frevenengine/freven-devkit#63.

Define the first public SDK contract layer for generic server-authoritative gameplay state.

## What changed

- add `freven_gameplay_state_sdk_types`
  - owner/scope identity
  - namespace + state key model
  - opaque/versioned value model
  - persistence/replication policy vocabulary
  - validation helpers and limits
- add `freven_gameplay_state_guest`
  - runtime-loaded mutation batch
  - query request/response family
  - service request/response family
- add `freven_gameplay_state_api`
  - builtin/compile-time gameplay-state view and authority traits
  - mutation result contract
- compose gameplay-state output and services through `freven_world_guest`
  - `RuntimeOutput.gameplay_state`
  - `WorldServiceRequest::GameplayState`
  - `WorldServiceResponse::GameplayState`
- update guest/ABI docs so the new output family is documented as gameplay-state-owned, not world-owned

## Why

`freven-devkit#63` needs a reusable gameplay-state substrate that is not a Vanilla-only selected-block/hotbar workaround.

This PR only defines the public contract vocabulary and carrier surfaces. It does not implement the engine runtime store, persistence, replication, Vanilla hotbar, or actor lifecycle.

## Non-goals

- no engine-side store yet
- no persistence implementation
- no replication implementation
- no Vanilla inventory/hotbar rewrite
- no actor/entity spawn/despawn lifecycle
- no client prediction helpers

## Validation

- `cargo +stable fmt --all -- --check`
- `cargo +stable test --workspace`
- `cargo +stable clippy --workspace --all-targets --all-features -- -D warnings`
