### PR TITLE
Stabilize custom block debug material authoring

### DIFF
--- a/crates/freven_block_sdk_types/src/lib.rs
+++ b/crates/freven_block_sdk_types/src/lib.rs
@@ -30,6 +30,27 @@ pub enum RenderLayer {
     Transparent,
 }
 
+/// Special author-facing material id for simple debug-colored blocks.
+///
+/// The current MVP renderer uses a 256-entry debug palette. Low-level callers may
+/// still provide explicit palette slots, but normal mod authoring should prefer
+/// the colored block helpers below. Those helpers use this sentinel so the host
+/// can resolve the block to a stable per-runtime-block palette slot during
+/// registry finalization / rendering.
+///
+/// This keeps raw renderer/palette slots out of the normal mod authoring path
+/// while preserving the existing wire/schema shape.
+pub const AUTO_DEBUG_MATERIAL_ID: u32 = u32::MAX;
+
+/// Current debug palette width used by the MVP voxel renderer.
+///
+/// This is intentionally documented as the legacy/debug palette range, not the
+/// long-term texture/material asset model.
+pub const DEBUG_PALETTE_WIDTH: u32 = 256;
+
+/// Maximum valid explicit debug palette material id for the current MVP renderer.
+pub const MAX_EXPLICIT_DEBUG_MATERIAL_ID: u32 = DEBUG_PALETTE_WIDTH - 1;
+
 /// Collision-facing reusable standard block/profile semantics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockCollision {
@@ -44,6 +65,16 @@ pub struct BlockVisibility {
 }
 
 /// Client presentation metadata for a standard block/profile entry.
+///
+/// `debug_tint_rgba` is authored as `0xRRGGBBAA`.
+///
+/// `material_id` is the current low-level debug-palette slot. Normal mod
+/// authors should not guess this value manually; use the `BlockDescriptor`
+/// colored helpers, which set [`AUTO_DEBUG_MATERIAL_ID`] and let the host choose
+/// a stable per-block palette slot.
+///
+/// Long term, real texture/material asset registration should live above this
+/// legacy debug-palette field and resolve to renderer-internal slots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockMaterial {
     pub debug_tint_rgba: u32,
@@ -88,6 +119,67 @@ impl BlockDescriptor {
         Self::new(false, false, RenderLayer::Opaque, 0, 0)
     }
 
+    /// Define a simple debug-colored cube without manually choosing a palette slot.
+    ///
+    /// The host resolves [`AUTO_DEBUG_MATERIAL_ID`] to a stable per-block debug
+    /// palette slot. This is the recommended current authoring path for simple
+    /// visible custom blocks until real texture/material asset registration lands.
+    #[must_use]
+    pub const fn colored_cube(
+        is_solid: bool,
+        is_opaque: bool,
+        render_layer: RenderLayer,
+        debug_tint_rgba: u32,
+    ) -> Self {
+        Self::new(
+            is_solid,
+            is_opaque,
+            render_layer,
+            debug_tint_rgba,
+            AUTO_DEBUG_MATERIAL_ID,
+        )
+    }
+
+    /// Define a normal opaque solid debug-colored cube.
+    #[must_use]
+    pub const fn solid_colored_cube(debug_tint_rgba: u32) -> Self {
+        Self::colored_cube(true, true, RenderLayer::Opaque, debug_tint_rgba)
+    }
+
+    /// Define a non-solid transparent debug-colored cube.
+    #[must_use]
+    pub const fn non_solid_colored_cube(debug_tint_rgba: u32) -> Self {
+        Self::colored_cube(false, false, RenderLayer::Transparent, debug_tint_rgba)
+    }
+
+    /// Define a solid cutout debug-colored cube.
+    #[must_use]
+    pub const fn cutout_colored_cube(debug_tint_rgba: u32) -> Self {
+        Self::colored_cube(true, false, RenderLayer::Cutout, debug_tint_rgba)
+    }
+
+    /// Define a solid transparent debug-colored cube.
+    #[must_use]
+    pub const fn transparent_colored_cube(debug_tint_rgba: u32) -> Self {
+        Self::colored_cube(true, false, RenderLayer::Transparent, debug_tint_rgba)
+    }
+
+    /// Override the material id with an explicit legacy debug-palette slot.
+    ///
+    /// Prefer the colored helpers for new mod authoring. This exists for
+    /// builtin/legacy/manual palette experiments that intentionally need a fixed
+    /// slot.
+    #[must_use]
+    pub const fn with_explicit_debug_material_id(mut self, material_id: u32) -> Self {
+        self.material.material_id = material_id;
+        self
+    }
+
+    #[must_use]
+    pub const fn uses_auto_debug_material_id(self) -> bool {
+        self.material_id() == AUTO_DEBUG_MATERIAL_ID
+    }
+
     #[must_use]
     pub const fn is_solid(self) -> bool {
         self.collision.is_solid
@@ -111,5 +203,31 @@ impl BlockDescriptor {
     #[must_use]
     pub const fn material_id(self) -> u32 {
         self.material.material_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn solid_colored_cube_uses_auto_debug_material_slot() {
+        let def = BlockDescriptor::solid_colored_cube(0x3C7A_52FF);
+
+        assert!(def.is_solid());
+        assert!(def.is_opaque());
+        assert_eq!(def.render_layer(), RenderLayer::Opaque);
+        assert_eq!(def.debug_tint_rgba(), 0x3C7A_52FF);
+        assert_eq!(def.material_id(), AUTO_DEBUG_MATERIAL_ID);
+        assert!(def.uses_auto_debug_material_id());
+    }
+
+    #[test]
+    fn explicit_debug_material_id_is_still_available_for_low_level_callers() {
+        let def =
+            BlockDescriptor::solid_colored_cube(0x8080_80FF).with_explicit_debug_material_id(7);
+
+        assert_eq!(def.material_id(), 7);
+        assert!(!def.uses_auto_debug_material_id());
     }
 }

--- a/crates/freven_world_guest_sdk/README.md
+++ b/crates/freven_world_guest_sdk/README.md
@@ -247,3 +247,17 @@ Recommended strategy:
   new `StartInput.session` arrives.
 - Wasm is the primary safe path. Native and external transports remain
   secondary transport integrations with separate operational tradeoffs.
+
+## Simple custom colored blocks
+
+For simple custom blocks, prefer the high-level colored helpers instead of manually choosing `material_id` values.
+
+Example:
+
+    use freven_world_guest_sdk::BlockDescriptor;
+
+    let block = BlockDescriptor::solid_colored_cube(0x3C7A_52FF);
+
+The helper uses an automatic debug material id. The host resolves that automatic id to a stable per-block palette slot, so multiple custom blocks can have distinct colors without mod authors guessing raw renderer indices.
+
+Manual `BlockDescriptor::new(..., material_id)` remains available for low-level legacy/debug-palette use, but it is not the recommended authoring path.

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -549,6 +549,35 @@ Builtin / compile-time execution is the same semantic system through a
 different execution path. Use `freven_mod_api` for neutral builtin authoring
 and `freven_world_api` for current world-stack builtin authoring.
 
+## Custom block visuals in the current debug-palette renderer
+
+For simple custom colored blocks, prefer the high-level `BlockDescriptor`
+helpers instead of manually guessing `material_id` values.
+
+Example:
+
+    use freven_world_guest_sdk::BlockDescriptor;
+
+    let leaves = BlockDescriptor::solid_colored_cube(0x2EA0_43FF);
+
+Current semantics:
+
+- `debug_tint_rgba` is authored as `0xRRGGBBAA`.
+- `BlockDescriptor::solid_colored_cube(...)` and related helpers use an automatic debug material id.
+- The host resolves automatic debug material ids to stable per-runtime-block palette slots.
+- Low-level explicit `material_id` values are legacy/debug-palette slots in the current MVP renderer.
+- Explicit material ids are not the long-term texture/material asset model and should not be guessed by normal mod authors.
+- The current debug palette has 256 slots because current block storage is still `u8`-backed.
+- Real namespaced texture/material asset registration is future work and should resolve to renderer-internal slots rather than exposing raw palette indices.
+
+`RenderLayer`, `is_opaque`, and `is_solid` are separate concerns:
+
+- `is_solid` controls collision/gameplay solidity.
+- `is_opaque` controls whether the block can occlude neighboring faces.
+- `RenderLayer::Opaque`, `Cutout`, and `Transparent` choose the client draw path.
+- Use opaque solid colored cubes for normal simple blocks.
+- Use transparent/cutout helpers only when the visual actually needs alpha.
+
 ## Reference docs
 
 - Canonical neutral guest contract: [NEUTRAL_GUEST_CONTRACT_v1.md](NEUTRAL_GUEST_CONTRACT_v1.md)


### PR DESCRIPTION
## Summary

Stabilizes the current custom block debug-material authoring contract.

Normal mod authors no longer need to guess raw `material_id` values for simple custom colored blocks. They can use the new colored `BlockDescriptor` helpers, which use an automatic debug material id resolved by the host.

## What changed

- Added `AUTO_DEBUG_MATERIAL_ID`.
- Documented the current 256-slot debug-palette material model.
- Added `BlockDescriptor::colored_cube(...)`.
- Added `BlockDescriptor::solid_colored_cube(...)`.
- Added cutout/transparent/non-solid colored helpers.
- Kept explicit `material_id` available as a low-level legacy/debug-palette path.
- Documented the recommended custom colored block path in Wasm authoring docs and world guest SDK README.

## Why

The current `material_id` field is renderer/debug-palette-facing detail. Custom block authors should be able to define simple visible colored blocks without knowing which vanilla/material slots are already used.

This keeps the current MVP palette renderer stable while leaving full namespaced texture/material asset registration to the broader architecture work.

Related:
- frevenengine/freven-sdk#43
- frevenengine/freven-sdk#44
- frevenengine/freven-devkit#15

## Validation

- `cargo +stable fmt --all`
- `cargo +stable test -p freven_block_sdk_types -p freven_world_guest_sdk`
- `cargo +stable clippy -p freven_block_sdk_types -p freven_world_guest_sdk --all-targets -- -D warnings`
