### PR TITLE
Add block tag SDK contracts

### DIFF
--- a/crates/freven_block_guest/src/lib.rs
+++ b/crates/freven_block_guest/src/lib.rs
@@ -51,14 +51,33 @@ impl BlockMutation {
 /// Authoritative/runtime block query family.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum BlockQueryRequest {
-    AuthoritativeBlock { pos: (i32, i32, i32) },
-    BlockIdByKey { key: String },
+    AuthoritativeBlock {
+        pos: (i32, i32, i32),
+    },
+    BlockIdByKey {
+        key: String,
+    },
+    /// Return whether `block_id` is a member of the semantic block tag.
+    ///
+    /// `tag_key` is a namespaced key such as `freven:stones` or
+    /// `modid:gas_permeable`. The host owns the resolved tag registry; this
+    /// query is only the transport-neutral SDK contract.
+    BlockHasTag {
+        block_id: BlockRuntimeId,
+        tag_key: String,
+    },
+    /// Return all runtime block ids currently resolved for a semantic block tag.
+    BlocksWithTag {
+        tag_key: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum BlockQueryResponse {
     AuthoritativeBlock(Option<BlockRuntimeId>),
     BlockIdByKey(Option<BlockRuntimeId>),
+    BlockHasTag(bool),
+    BlocksWithTag(Vec<BlockRuntimeId>),
 }
 
 /// Client-visible block query family.
@@ -83,4 +102,34 @@ pub enum BlockServiceRequest {
 pub enum BlockServiceResponse {
     Query(BlockQueryResponse),
     ClientQuery(BlockClientQueryResponse),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_tag_queries_are_transport_neutral_contract_shapes() {
+        let block_id = BlockRuntimeId(7);
+        let tag_key = "freven:stones".to_string();
+
+        let has_tag = BlockQueryRequest::BlockHasTag {
+            block_id,
+            tag_key: tag_key.clone(),
+        };
+        assert_eq!(
+            has_tag,
+            BlockQueryRequest::BlockHasTag {
+                block_id,
+                tag_key: tag_key.clone()
+            }
+        );
+
+        let blocks = BlockQueryResponse::BlocksWithTag(vec![block_id]);
+        assert_eq!(blocks, BlockQueryResponse::BlocksWithTag(vec![block_id]));
+        assert_eq!(
+            BlockQueryResponse::BlockHasTag(true),
+            BlockQueryResponse::BlockHasTag(true)
+        );
+    }
 }

--- a/crates/freven_block_sdk_types/src/lib.rs
+++ b/crates/freven_block_sdk_types/src/lib.rs
@@ -89,13 +89,12 @@ const MATERIAL_KEY_HASH_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
 /// FNV-1a prime for stable material-key hashing.
 const MATERIAL_KEY_HASH_PRIME: u64 = 0x0000_0100_0000_01B3;
 
-/// Compute the stable compact hash used to carry namespaced material-key identity.
+/// Compute the stable compact hash used to carry namespaced resource-key identity.
 ///
-/// The original namespaced key remains the authoring/debug/error-reporting
-/// surface. This hash is only a compact deterministic ABI/runtime identity and
-/// must not be treated as a renderer slot.
+/// This is shared by material keys, block tag keys, and other compact
+/// `namespace:path` identities that need deterministic ABI/runtime fingerprints.
 #[must_use]
-pub const fn material_key_hash(key: &str) -> u64 {
+pub const fn namespaced_key_hash(key: &str) -> u64 {
     let bytes = key.as_bytes();
     let mut hash = MATERIAL_KEY_HASH_OFFSET_BASIS;
     let mut i = 0usize;
@@ -109,6 +108,43 @@ pub const fn material_key_hash(key: &str) -> u64 {
     hash
 }
 
+/// Compute the stable compact hash used to carry namespaced material-key identity.
+///
+/// The original namespaced key remains the authoring/debug/error-reporting
+/// surface. This hash is only a compact deterministic ABI/runtime identity and
+/// must not be treated as a renderer slot.
+#[must_use]
+pub const fn material_key_hash(key: &str) -> u64 {
+    namespaced_key_hash(key)
+}
+
+/// Compute the stable compact hash used to carry namespaced block-tag identity.
+///
+/// The readable tag key remains the public authoring/debug surface. This hash is
+/// only a compact deterministic ABI/runtime identity and must not be treated as
+/// a runtime block id, renderer slot, or gameplay-specific meaning.
+#[must_use]
+pub const fn block_tag_key_hash(key: &str) -> u64 {
+    namespaced_key_hash(key)
+}
+
+/// Returns true when `key` is a stable Freven namespaced resource key.
+///
+/// The accepted MVP shape is `namespace:path`, where the namespace allows
+/// lowercase ASCII letters, digits, `_`, `-`, and `.`, and the path also allows
+/// `/` for folders.
+#[must_use]
+pub fn is_valid_namespaced_key(key: &str) -> bool {
+    let Some((namespace, path)) = key.split_once(':') else {
+        return false;
+    };
+
+    !namespace.is_empty()
+        && !path.is_empty()
+        && namespace.bytes().all(is_valid_namespace_byte)
+        && path.bytes().all(is_valid_resource_path_byte)
+}
+
 /// Returns true when `key` is a stable Freven namespaced material key.
 ///
 /// The accepted MVP shape is `namespace:path`, where the namespace allows
@@ -117,14 +153,17 @@ pub const fn material_key_hash(key: &str) -> u64 {
 /// instead of exposing renderer-local numeric ids.
 #[must_use]
 pub fn is_valid_material_key(key: &str) -> bool {
-    let Some((namespace, path)) = key.split_once(':') else {
-        return false;
-    };
+    is_valid_namespaced_key(key)
+}
 
-    !namespace.is_empty()
-        && !path.is_empty()
-        && namespace.bytes().all(is_valid_namespace_byte)
-        && path.bytes().all(is_valid_material_path_byte)
+/// Returns true when `key` is a stable Freven namespaced block tag key.
+///
+/// Block tags are semantic content groupings such as `freven:stones` or
+/// `modid:gas_permeable`. They are not block runtime ids, renderer ids, or
+/// hardcoded engine gameplay concepts.
+#[must_use]
+pub fn is_valid_block_tag_key(key: &str) -> bool {
+    is_valid_namespaced_key(key)
 }
 
 #[inline]
@@ -133,7 +172,7 @@ fn is_valid_namespace_byte(b: u8) -> bool {
 }
 
 #[inline]
-fn is_valid_material_path_byte(b: u8) -> bool {
+fn is_valid_resource_path_byte(b: u8) -> bool {
     is_valid_namespace_byte(b) || b == b'/'
 }
 
@@ -438,5 +477,24 @@ mod tests {
             material_key_hash("freven.test:block/green"),
             material_key_hash("freven.test:block/brown")
         );
+    }
+    #[test]
+    fn block_tag_key_validation_uses_namespaced_resource_shape() {
+        assert!(is_valid_block_tag_key("freven:stones"));
+        assert!(is_valid_block_tag_key("freven:terrain/solids"));
+        assert!(is_valid_block_tag_key("example.mod:gas_permeable"));
+        assert!(!is_valid_block_tag_key("missing_namespace"));
+        assert!(!is_valid_block_tag_key(":missing_namespace"));
+        assert!(!is_valid_block_tag_key("freven:"));
+        assert!(!is_valid_block_tag_key("Freven:stones"));
+        assert!(!is_valid_block_tag_key("freven:bad tag"));
+    }
+
+    #[test]
+    fn block_tag_key_hash_is_stable_and_shared_with_namespaced_hash() {
+        let key = "freven:stones";
+        assert_eq!(block_tag_key_hash(key), namespaced_key_hash(key));
+        assert_eq!(block_tag_key_hash(key), block_tag_key_hash(key));
+        assert_ne!(block_tag_key_hash(key), block_tag_key_hash("freven:soils"));
     }
 }

--- a/crates/freven_volumetric_api/src/lib.rs
+++ b/crates/freven_volumetric_api/src/lib.rs
@@ -69,6 +69,14 @@ pub struct WorldGenInit {
     /// The ids are block-layer vocabulary imported from
     /// `freven_block_sdk_types`.
     pub block_ids: BTreeMap<String, BlockRuntimeId>,
+    /// Resolved semantic block tag membership for worldgen convenience.
+    ///
+    /// Keys are namespaced block tag keys such as `freven:stones`. Values are
+    /// runtime block ids resolved by the host for the active world/session.
+    ///
+    /// The host owns the canonical tag registry. Worldgen providers should treat
+    /// this as a read-only resolved view, not as an authoring surface.
+    pub block_tags: BTreeMap<String, Vec<BlockRuntimeId>>,
 }
 
 impl WorldGenInit {
@@ -78,12 +86,24 @@ impl WorldGenInit {
             seed,
             world_id: None,
             block_ids: BTreeMap::new(),
+            block_tags: BTreeMap::new(),
         }
     }
 
     #[must_use]
     pub fn block_id_by_key(&self, key: &str) -> Option<BlockRuntimeId> {
         self.block_ids.get(key).copied()
+    }
+
+    #[must_use]
+    pub fn blocks_with_tag(&self, tag_key: &str) -> Option<&[BlockRuntimeId]> {
+        self.block_tags.get(tag_key).map(Vec::as_slice)
+    }
+
+    #[must_use]
+    pub fn block_has_tag(&self, block_id: BlockRuntimeId, tag_key: &str) -> bool {
+        self.blocks_with_tag(tag_key)
+            .is_some_and(|blocks| blocks.contains(&block_id))
     }
 }
 
@@ -244,5 +264,23 @@ mod tests {
 
         assert!(output.bootstrap.initial_world_spawn_hint.is_none());
         assert!(output.writes.is_empty());
+    }
+
+    #[test]
+    fn worldgen_init_exposes_resolved_block_tags() {
+        let mut init = crate::WorldGenInit::new(42);
+        let stone = BlockRuntimeId(1);
+        let dirt = BlockRuntimeId(2);
+
+        init.block_ids
+            .insert("freven.vanilla:stone".to_string(), stone);
+        init.block_tags
+            .insert("freven:terrain_solids".to_string(), vec![stone, dirt]);
+
+        assert_eq!(init.block_id_by_key("freven.vanilla:stone"), Some(stone));
+        assert!(init.block_has_tag(stone, "freven:terrain_solids"));
+        assert!(init.block_has_tag(dirt, "freven:terrain_solids"));
+        assert!(!init.block_has_tag(BlockRuntimeId(9), "freven:terrain_solids"));
+        assert_eq!(init.blocks_with_tag("missing"), None);
     }
 }

--- a/crates/freven_world_guest_sdk/README.md
+++ b/crates/freven_world_guest_sdk/README.md
@@ -248,6 +248,32 @@ Recommended strategy:
 - Wasm is the primary safe path. Native and external transports remain
   secondary transport integrations with separate operational tradeoffs.
 
+## Semantic block tag queries
+
+Semantic block tags are the cross-mod compatibility layer for asking about
+content by meaning instead of hardcoding exact block keys. Tags use namespaced
+keys such as `freven:stones` or `modid:gas_permeable`.
+
+The SDK owns the transport-neutral query contract:
+
+    let services = freven_world_guest_sdk::RuntimeServices;
+    if let Some(stone) = services.block_id_by_key("freven.vanilla:stone") {
+        match services.block_has_tag(stone, "freven:stones") {
+            freven_world_guest_sdk::RuntimeQuerySupport::Supported(true) => {
+                // stone is currently resolved as a member of freven:stones
+            }
+            freven_world_guest_sdk::RuntimeQuerySupport::Supported(false) => {
+                // the tag registry exists, but this block is not a member
+            }
+            freven_world_guest_sdk::RuntimeQuerySupport::Unsupported => {
+                // the active host/runtime does not expose block tag queries yet
+            }
+        }
+    }
+
+The host/runtime owns the resolved tag registry. Tags are not renderer ids,
+runtime block ids, or hardcoded engine gameplay concepts.
+
 ## Simple custom colored blocks
 
 For simple custom blocks, prefer the high-level colored helpers instead of manually choosing `material_id` values.

--- a/crates/freven_world_guest_sdk/src/lib.rs
+++ b/crates/freven_world_guest_sdk/src/lib.rs
@@ -13,6 +13,7 @@ pub use freven_block_guest::{
 };
 pub use freven_block_sdk_types::{
     BlockCollision, BlockDescriptor, BlockMaterial, BlockRuntimeId, BlockVisibility, RenderLayer,
+    block_tag_key_hash, is_valid_block_tag_key,
 };
 use freven_guest::{
     CapabilityDeclaration, ChannelConfig, ChannelDeclaration, ComponentCodec, ComponentDeclaration,
@@ -1378,6 +1379,55 @@ impl RuntimeServices {
                 BlockQueryResponse::BlockIdByKey(value),
             )) => value,
             _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn block_has_tag(
+        self,
+        block_id: BlockRuntimeId,
+        tag_key: &str,
+    ) -> RuntimeQuerySupport<bool> {
+        match runtime_service_call(WorldServiceRequest::Block(BlockServiceRequest::Query(
+            BlockQueryRequest::BlockHasTag {
+                block_id,
+                tag_key: tag_key.to_string(),
+            },
+        ))) {
+            WorldServiceResponse::Block(BlockServiceResponse::Query(
+                BlockQueryResponse::BlockHasTag(value),
+            )) => RuntimeQuerySupport::Supported(value),
+            WorldServiceResponse::Unsupported => RuntimeQuerySupport::Unsupported,
+            other => {
+                debug_assert!(
+                    false,
+                    "unexpected response for BlockHasTag query: {:?}",
+                    other
+                );
+                RuntimeQuerySupport::Unsupported
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn blocks_with_tag(self, tag_key: &str) -> RuntimeQuerySupport<Vec<BlockRuntimeId>> {
+        match runtime_service_call(WorldServiceRequest::Block(BlockServiceRequest::Query(
+            BlockQueryRequest::BlocksWithTag {
+                tag_key: tag_key.to_string(),
+            },
+        ))) {
+            WorldServiceResponse::Block(BlockServiceResponse::Query(
+                BlockQueryResponse::BlocksWithTag(value),
+            )) => RuntimeQuerySupport::Supported(value),
+            WorldServiceResponse::Unsupported => RuntimeQuerySupport::Unsupported,
+            other => {
+                debug_assert!(
+                    false,
+                    "unexpected response for BlocksWithTag query: {:?}",
+                    other
+                );
+                RuntimeQuerySupport::Unsupported
+            }
         }
     }
 

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -549,6 +549,32 @@ Builtin / compile-time execution is the same semantic system through a
 different execution path. Use `freven_mod_api` for neutral builtin authoring
 and `freven_world_api` for current world-stack builtin authoring.
 
+## Semantic block tag queries
+
+Semantic block tags are the cross-mod compatibility layer for asking about
+content by meaning instead of hardcoding exact block keys. Tags use namespaced
+keys such as `freven:stones` or `modid:gas_permeable`.
+
+The SDK owns the transport-neutral query contract:
+
+    let services = freven_world_guest_sdk::RuntimeServices;
+    if let Some(stone) = services.block_id_by_key("freven.vanilla:stone") {
+        match services.block_has_tag(stone, "freven:stones") {
+            freven_world_guest_sdk::RuntimeQuerySupport::Supported(true) => {
+                // stone is currently resolved as a member of freven:stones
+            }
+            freven_world_guest_sdk::RuntimeQuerySupport::Supported(false) => {
+                // the tag registry exists, but this block is not a member
+            }
+            freven_world_guest_sdk::RuntimeQuerySupport::Unsupported => {
+                // the active host/runtime does not expose block tag queries yet
+            }
+        }
+    }
+
+The host/runtime owns the resolved tag registry. Tags are not renderer ids,
+runtime block ids, or hardcoded engine gameplay concepts.
+
 ## Custom block visuals in the current debug-palette renderer
 
 For simple custom colored blocks, prefer the high-level `BlockDescriptor`


### PR DESCRIPTION
## Summary

Adds the SDK-side contract slice for Block Tag Registry v1.

This introduces:

- reusable namespaced key hashing/validation
- block tag key validation and hashing helpers
- transport-neutral block tag query request/response variants
- high-level `RuntimeServices` helpers for tag queries
- resolved `WorldGenInit.block_tags` for worldgen convenience
- authoring docs explaining semantic block tags as cross-mod compatibility metadata

This intentionally does not implement engine-side manifest parsing, resolved registry construction, runtime backing services, Vanilla tag declarations, or DevKit packaging/docs checks. Those are tracked in the cross-repo child issues.

## Validation

- `cargo +stable fmt --all -- --check`
- `cargo +stable test -p freven_block_sdk_types -p freven_block_guest -p freven_volumetric_api -p freven_world_guest_sdk`
- `cargo +stable clippy -p freven_block_sdk_types -p freven_block_guest -p freven_volumetric_api -p freven_world_guest_sdk --all-targets -- -D warnings`
- `git --no-pager diff --check`

## Related

Closes #64

Parent:
- frevenengine/freven-devkit#55

Follow-up implementation chain:
- frevenengine/freven-engine#267
- frevenengine/freven-vanilla#26
- frevenengine/freven-boot#79
