### PR TITLE
Add bulk block mutation contract

### DIFF
--- a/crates/freven_block_guest/src/lib.rs
+++ b/crates/freven_block_guest/src/lib.rs
@@ -25,6 +25,27 @@ impl BlockMutationBatch {
     }
 }
 
+/// A single cell edit carried by a bulk block mutation.
+///
+/// `expected_old` keeps the same compare-and-set meaning as scalar `SetBlock`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlockEdit {
+    pub pos: (i32, i32, i32),
+    pub block_id: BlockRuntimeId,
+    pub expected_old: Option<BlockRuntimeId>,
+}
+
+/// Replacement policy for region-style block mutations.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum BlockReplacePolicy {
+    /// Replace any currently loaded block.
+    Any,
+    /// Replace only air blocks.
+    OnlyAir,
+    /// Replace only blocks matching the expected runtime id.
+    Matching(BlockRuntimeId),
+}
+
 /// Runtime output block mutations.
 ///
 /// This is standard block gameplay/runtime vocabulary, not generic world truth.
@@ -34,6 +55,23 @@ pub enum BlockMutation {
         pos: (i32, i32, i32),
         block_id: BlockRuntimeId,
         expected_old: Option<BlockRuntimeId>,
+    },
+    /// Apply a compact list of independent cell edits.
+    ///
+    /// Hosts may normalize, de-duplicate, budget, and group these edits by
+    /// chunk/section before applying them, but the semantic payload remains a
+    /// deterministic list of compare-and-set cell edits.
+    SetBlocks { edits: Vec<BlockEdit> },
+    /// Fill a half-open world-cell box: `[min, max)`.
+    ///
+    /// This intentionally matches the half-open bounds used by
+    /// `WorldTerrainWrite::FillBox` so runtime mutations and worldgen writes use
+    /// the same spatial convention.
+    FillBox {
+        min: (i32, i32, i32),
+        max: (i32, i32, i32),
+        block_id: BlockRuntimeId,
+        replace: BlockReplacePolicy,
     },
 }
 
@@ -107,6 +145,41 @@ pub enum BlockServiceResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bulk_block_mutations_are_transport_neutral_contract_shapes() {
+        let block_id = BlockRuntimeId(7);
+        let edit = BlockEdit {
+            pos: (1, 2, 3),
+            block_id,
+            expected_old: Some(BlockRuntimeId(2)),
+        };
+
+        assert_eq!(
+            BlockMutation::SetBlocks {
+                edits: vec![edit.clone()]
+            },
+            BlockMutation::SetBlocks { edits: vec![edit] }
+        );
+        assert_eq!(
+            BlockMutation::FillBox {
+                min: (0, 0, 0),
+                max: (16, 16, 16),
+                block_id,
+                replace: BlockReplacePolicy::OnlyAir,
+            },
+            BlockMutation::FillBox {
+                min: (0, 0, 0),
+                max: (16, 16, 16),
+                block_id,
+                replace: BlockReplacePolicy::OnlyAir,
+            }
+        );
+        assert_eq!(
+            BlockReplacePolicy::Matching(block_id),
+            BlockReplacePolicy::Matching(block_id)
+        );
+    }
 
     #[test]
     fn block_tag_queries_are_transport_neutral_contract_shapes() {

--- a/crates/freven_world_api/README.md
+++ b/crates/freven_world_api/README.md
@@ -102,3 +102,8 @@ assert!(ModSide::Both.matches(Side::Client));
 * ABI docs: `docs/WASM_ABI_v1.md`, `docs/NATIVE_MOD_ABI_v1.md`,
   `docs/EXTERNAL_MOD_IPC_v1.md`
 * Safety note: `docs/UNSAFE_NATIVE_MODS.md`
+
+Runtime block mutation output may use scalar `BlockMutation::SetBlock` for
+single-cell actions, `BlockMutation::SetBlocks` for compact cell-edit batches,
+or half-open `BlockMutation::FillBox` for region-style edits. Hosts own budget
+validation, deterministic application, and replication/coalescing policy.

--- a/crates/freven_world_guest_sdk/src/lib.rs
+++ b/crates/freven_world_guest_sdk/src/lib.rs
@@ -8,8 +8,9 @@ use core::ffi::c_void;
 use std::thread::LocalKey;
 
 pub use freven_block_guest::{
-    BlockClientQueryRequest, BlockClientQueryResponse, BlockMutation, BlockMutationBatch,
-    BlockQueryRequest, BlockQueryResponse, BlockServiceRequest, BlockServiceResponse,
+    BlockClientQueryRequest, BlockClientQueryResponse, BlockEdit, BlockMutation,
+    BlockMutationBatch, BlockQueryRequest, BlockQueryResponse, BlockReplacePolicy,
+    BlockServiceRequest, BlockServiceResponse,
 };
 pub use freven_block_sdk_types::{
     BlockCollision, BlockDescriptor, BlockMaterial, BlockRuntimeId, BlockVisibility, RenderLayer,
@@ -1762,6 +1763,27 @@ impl AppliedActionResponse {
     }
 
     #[must_use]
+    pub fn set_blocks(self, edits: Vec<BlockEdit>) -> Self {
+        self.push_block_mutation(BlockMutation::SetBlocks { edits })
+    }
+
+    #[must_use]
+    pub fn fill_box(
+        self,
+        min: (i32, i32, i32),
+        max: (i32, i32, i32),
+        block_id: BlockRuntimeId,
+        replace: BlockReplacePolicy,
+    ) -> Self {
+        self.push_block_mutation(BlockMutation::FillBox {
+            min,
+            max,
+            block_id,
+            replace,
+        })
+    }
+
+    #[must_use]
     pub fn send_client(mut self, message: ClientOutboundMessage) -> Self {
         self.output.messages.client.push(message);
         self
@@ -1859,6 +1881,32 @@ impl ClientMessageResponse {
     }
 
     #[must_use]
+    pub fn set_blocks(mut self, edits: Vec<BlockEdit>) -> Self {
+        self.output
+            .blocks
+            .mutations
+            .push(BlockMutation::SetBlocks { edits });
+        self
+    }
+
+    #[must_use]
+    pub fn fill_box(
+        mut self,
+        min: (i32, i32, i32),
+        max: (i32, i32, i32),
+        block_id: BlockRuntimeId,
+        replace: BlockReplacePolicy,
+    ) -> Self {
+        self.output.blocks.mutations.push(BlockMutation::FillBox {
+            min,
+            max,
+            block_id,
+            replace,
+        });
+        self
+    }
+
+    #[must_use]
     pub fn finish(self) -> ClientMessageResult {
         ClientMessageResult {
             output: self.output,
@@ -1921,6 +1969,32 @@ impl ServerMessageResponse {
     }
 
     #[must_use]
+    pub fn set_blocks(mut self, edits: Vec<BlockEdit>) -> Self {
+        self.output
+            .blocks
+            .mutations
+            .push(BlockMutation::SetBlocks { edits });
+        self
+    }
+
+    #[must_use]
+    pub fn fill_box(
+        mut self,
+        min: (i32, i32, i32),
+        max: (i32, i32, i32),
+        block_id: BlockRuntimeId,
+        replace: BlockReplacePolicy,
+    ) -> Self {
+        self.output.blocks.mutations.push(BlockMutation::FillBox {
+            min,
+            max,
+            block_id,
+            replace,
+        });
+        self
+    }
+
+    #[must_use]
     pub fn finish(self) -> ServerMessageResult {
         ServerMessageResult {
             output: self.output,
@@ -1952,6 +2026,32 @@ impl LifecycleResponse {
             pos,
             block_id,
             expected_old: None,
+        });
+        self
+    }
+
+    #[must_use]
+    pub fn set_blocks(mut self, edits: Vec<BlockEdit>) -> Self {
+        self.output
+            .blocks
+            .mutations
+            .push(BlockMutation::SetBlocks { edits });
+        self
+    }
+
+    #[must_use]
+    pub fn fill_box(
+        mut self,
+        min: (i32, i32, i32),
+        max: (i32, i32, i32),
+        block_id: BlockRuntimeId,
+        replace: BlockReplacePolicy,
+    ) -> Self {
+        self.output.blocks.mutations.push(BlockMutation::FillBox {
+            min,
+            max,
+            block_id,
+            replace,
         });
         self
     }

--- a/docs/GUEST_CONTRACT_v1.md
+++ b/docs/GUEST_CONTRACT_v1.md
@@ -255,6 +255,14 @@ Current block-mutation family carried by runtime output includes:
 - `RuntimeOutput.blocks`
 - `BlockMutationBatch.mutations`
 - `BlockMutation::SetBlock { pos, block_id, expected_old }`
+- `BlockMutation::SetBlocks { edits }`
+- `BlockMutation::FillBox { min, max, block_id, replace }`
+
+`BlockMutation::FillBox` uses half-open absolute world-cell bounds:
+
+```text
+[min.x, max.x) x [min.y, max.y) x [min.z, max.z)
+```
 
 Current gameplay-state mutation family carried by runtime output includes:
 

--- a/docs/WASM_ABI_v1.md
+++ b/docs/WASM_ABI_v1.md
@@ -173,6 +173,14 @@ Current block-mutation family carried by `RuntimeOutput`:
 - `RuntimeOutput.blocks`
 - `BlockMutationBatch.mutations`
 - `BlockMutation::SetBlock { pos, block_id, expected_old }`
+- `BlockMutation::SetBlocks { edits }`
+- `BlockMutation::FillBox { min, max, block_id, replace }`
+
+`BlockMutation::FillBox` uses half-open absolute world-cell bounds:
+
+```text
+[min.x, max.x) x [min.y, max.y) x [min.z, max.z)
+```
 
 Current gameplay-state mutation family carried by `RuntimeOutput`:
 


### PR DESCRIPTION
## Summary

Adds the SDK-side runtime block mutation contract needed for frevenengine/freven-devkit#54.

This introduces transport-neutral bulk mutation shapes:

- `BlockEdit`
- `BlockReplacePolicy`
- `BlockMutation::SetBlocks`
- `BlockMutation::FillBox`

It also exposes guest-authoring helpers on applied action, lifecycle, client-message, and server-message response builders.

## Why

Simulation-style mods should not be forced to express large world changes as thousands of scalar `SetBlock` mutations.

This PR only adds the SDK contract and authoring surface. Engine-side validation, budgeting, deterministic apply, and replication/coalescing are intentionally left for follow-up PRs.

## Bounds semantics

`BlockMutation::FillBox` uses half-open absolute world-cell bounds:

`[min.x, max.x) x [min.y, max.y) x [min.z, max.z)`

This matches the existing `WorldTerrainWrite::FillBox` convention used by worldgen output.

## Scope

This PR does not:

- implement engine-side apply logic for the new variants;
- change runtime mutation budgets;
- change server replication;
- close frevenengine/freven-devkit#54.

It is the SDK contract step in the #54 implementation chain.

## Validation

- `cargo +stable fmt --all`
- `cargo +stable fmt --all -- --check`
- `cargo +stable --locked test -p freven_block_guest`
- `cargo +stable --locked test -p freven_world_guest`
- `cargo +stable --locked test -p freven_world_guest_sdk`
- `cargo +stable --locked test --workspace`
- `cargo +stable --locked clippy --workspace --all-targets -- -D warnings`