### PR TITLE
Document Freven architecture model

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ It is **not**:
 
 ## Freven architecture at a glance
 
+For the canonical architecture and ownership vocabulary, see
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). That document defines the
+engine / SDK / experience / Vanilla / mod / content-pack /
+standalone-product boundaries used by the rc10 visual/data foundation work.
+
 The current long-term direction is:
 
 - **engine/platform layer**: neutral runtime/platform substrate

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,220 @@
+# Freven Architecture Model
+
+This document defines the recommended public architecture vocabulary for Freven
+SDK authors.
+
+Freven is a platform for experiences, not only a single game or a thin mod
+loader. The most important boundary is that the engine provides generic
+capabilities, the SDK defines public contracts, and gameplay/content layers own
+their authored meaning.
+
+This document intentionally stays at the architecture and ownership level.
+Detailed file ownership, visual asset schemas, override rules, and patch/merge
+semantics are defined by follow-up documents.
+
+## Goals
+
+- Keep engine/runtime implementation details out of normal author APIs.
+- Keep Vanilla gameplay, content, visuals, and style out of engine core.
+- Give mods, content packs, standalone games, and total conversions one shared
+  vocabulary.
+- Make data, assets, config, and save state boundaries explicit before rc10
+  visual/data work grows.
+- Preserve a future path for creator-friendly scripting without making it a
+  separate platform model.
+
+## Layer model
+
+| Layer | Owns | Does not own |
+| --- | --- | --- |
+| Engine / platform | runtime host, renderer, networking, storage, asset resolver, scheduling, sandboxing, diagnostics, cache, authoritative apply paths | Vanilla gameplay, first-party content, author-facing schemas, mod policy decisions baked as gameplay meaning |
+| SDK | public contracts, schemas, namespaced identities, guest APIs, capability vocabulary, author-facing validation model | engine internals, renderer slots, Bevy/wgpu types, concrete Vanilla content |
+| Game / gameplay SDK roots | explicit world, volumetric, block, avatar, gameplay-state, item, UI, input, effect, and save contracts above the neutral SDK roots | neutral platform ownership, renderer implementation, first-party Vanilla semantics |
+| Experience | a concrete playable root such as Vanilla, a minigame, a total conversion, or a standalone game experience | engine implementation details |
+| Vanilla | first-party reference experience, default gameplay/content/style, reference integration patterns | platform ownership, required dependency for all games |
+| Standalone product | distribution boundary, bundled engine/devkit/runtime pieces, selected experience(s), default config, packaged content/assets | a requirement to include Vanilla |
+| Mod | code/data/assets package that extends or patches a target experience through declared dependencies and capabilities | unrestricted engine access, implicit ownership of another namespace |
+| Content pack | data/assets-only package for adding or overriding authored content through explicit rules | executable code, runtime authority by itself |
+| Script pack | future creator-friendly scripting package that uses the same public contracts and capability model | a separate hidden runtime model |
+| Save/world state | persistent runtime state bound to a world/session and compatible content identity | shipped content defaults, manifest metadata, generated asset cache |
+
+## Core definitions
+
+### Engine / platform
+
+The engine is the generic host implementation. It can know how to render, load,
+resolve, validate, cache, simulate, network, store, sandbox, and apply runtime
+commands.
+
+The engine must not need to know what `grass`, `stone`, `vanilla:pickaxe`, or a
+Vanilla humanoid means. It should operate on resolved contracts, validated data,
+namespaced identities, internal handles, and authoritative runtime state.
+
+Normal author APIs must not expose renderer-internal slots, palette ids, atlas
+coordinates, Bevy-specific component names, or other host implementation details.
+
+### SDK
+
+The SDK is the public contract layer. It defines what authors can depend on:
+guest contracts, SDK crates, schemas, namespaced keys, config schema vocabulary,
+runtime service requests, capability declarations, diagnostics vocabulary, and
+data model conventions.
+
+The SDK can describe public meaning. It should not implement the engine runtime,
+own first-party Vanilla content, or force every experience to inherit Vanilla.
+
+### Game / gameplay SDK roots
+
+Neutral SDK roots describe platform-shaped concepts such as lifecycle, messages,
+channels, capabilities, session identity, and observability.
+
+Game SDK roots describe explicit gameplay-owned concepts above the neutral
+platform layer. Today that includes world, volumetric, block, avatar, and
+gameplay-state contracts. Future roots may own items, entities, UI,
+effects, input, save contracts, or other game-facing APIs.
+
+World/gameplay-specific concepts live under explicit owner roots such as
+`freven_world_*`, `freven_volumetric_*`, `freven_block_*`, and future equivalent
+roots. This keeps block/voxel/world assumptions from becoming the neutral Freven
+platform story.
+
+### Experience
+
+An experience is a concrete playable root. Examples include:
+
+- first-party Vanilla;
+- a Vanilla-derived modded experience;
+- a minigame;
+- a total conversion;
+- a standalone game with no Vanilla dependency.
+
+An experience owns its active mod/content stack, default authored config, content
+baseline, and gameplay identity. It can depend on other packages, but it should
+do so explicitly.
+
+### Vanilla
+
+Vanilla is the first-party reference experience. It is important because it shows
+how the platform is meant to be used, but it is not the platform itself.
+
+Vanilla may own blocks, items, recipes, movement style, visuals, UI decisions,
+and reference content. Engine and neutral SDK layers must not hardcode those
+choices. Standalone games and total conversions must be able to replace Vanilla
+completely.
+
+### Mod
+
+A mod is an extension unit. It may include executable guest code, content data,
+assets, config schema, and migrations depending on its declared artifact,
+execution, trust, surfaces, and capabilities.
+
+A mod extends or patches a target experience through explicit dependencies,
+declared capabilities, namespaced identities, and resolver rules. A mod should
+not silently take ownership of another namespace or rely on load-order accidents.
+
+### Content pack
+
+A content pack is data/assets only. It can add, replace, or patch authored
+content only through explicit content and asset rules.
+
+A content pack is the right shape for simple visual/content changes that do not
+need executable code. It must not get runtime authority just because it can
+provide data or assets.
+
+### Script pack
+
+A script pack is a future creator-friendly executable layer for languages above
+the lower-level Rust/Wasm path.
+
+Script packs should use the same platform contracts, capability checks,
+namespaces, budgets, diagnostics, and authority model as other guest execution
+paths. They should not become a second hidden mod architecture.
+
+### Standalone product
+
+A standalone product is a packaging and distribution boundary. It can bundle a
+runtime, selected experiences, default config, content, assets, and product shell
+files.
+
+A standalone product may include Vanilla, extend Vanilla, or ship a zero-Vanilla
+experience. Product packaging must not imply that Vanilla is required by the
+engine or SDK.
+
+## Package and state boundaries
+
+The architecture uses these high-level boundaries:
+
+| Boundary | Purpose |
+| --- | --- |
+| Manifest | package identity, version, dependencies, artifact/execution/trust metadata, surfaces, entrypoint, capability requests, schema references |
+| Config schema | supported settings, defaults, validation constraints, reload policy, authority |
+| Active config | selected values resolved from the active experience or stack |
+| Content data | authored gameplay/visual definitions such as blocks, items, recipes, materials, models, providers, families |
+| Assets | referenced files such as images, models, shaders, sounds, fonts, and other resource data |
+| Generated cache | host/devkit-owned derived data such as atlases, load plans, fingerprints, and compiled cache artifacts |
+| Save/world state | persistent runtime state produced by play and simulation |
+
+Detailed rules for these file and state boundaries belong in the manifest,
+config, content, asset, and save-state documents. The core architecture rule is
+that shipped defaults, active config, generated cache, and save/world state are
+not the same thing.
+
+## Composition model
+
+A typical Freven launch resolves in this conceptual order:
+
+1. Select a product or install boundary.
+2. Select an experience or experience stack.
+3. Resolve declared packages, dependencies, trust policy, and active sides.
+4. Resolve config schemas and active config values.
+5. Resolve content data and visual assets through deterministic layer rules.
+6. Build host-internal load plans, caches, and runtime handles.
+7. Start the server/client runtime with only the resolved public contracts.
+8. Persist runtime state into save/world state, not back into shipped content.
+
+This model should work for Vanilla, Vanilla mods, content packs, total
+conversions, and standalone games.
+
+## Authority and compatibility
+
+Author-facing identity should be namespaced and stable. Runtime and tooling must
+distinguish at least these categories:
+
+- authoritative server-required content and gameplay contracts;
+- client-local cosmetic assets where allowed;
+- generated cache that can be rebuilt;
+- save/world state that may require migration when authoritative content changes.
+
+A client-local texture override should not be treated the same as a server-side
+block definition change. A generated atlas should not be treated as authored
+source. A save migration should not be expressed by editing a shipped content
+file at runtime.
+
+## Non-goals for this document
+
+This document does not define the full schemas for:
+
+- manifest vs config vs content data vs assets vs save state;
+- visual asset keys, materials, models, textures, shaders, or atlases;
+- layered asset override rules;
+- data-driven content patch and merge semantics;
+- beginner-friendly data authoring formats;
+- future scripting-language bindings.
+
+Those are separate SDK and DevKit documents/issues that should reference this
+architecture vocabulary instead of redefining it.
+
+## Practical rules for contributors
+
+- Put generic host capabilities in the engine, not in Vanilla.
+- Put stable author-facing contracts in the SDK, not in engine internals.
+- Put first-party gameplay/content/style in Vanilla, not in the engine.
+- Put package identity and capability requests in manifests, not active runtime
+  config.
+- Put active values in experience/stack config, not `mod.toml`.
+- Put authored content in content data and assets, not save/world state.
+- Put generated resolver output in cache/load-plan data, not authored source.
+- Keep every override, patch, and dependency decision explicit and diagnosable.
+- Prefer namespaced keys over renderer slots or raw host ids in public APIs.
+- Design every new rc10 visual/data feature so a zero-Vanilla standalone game can
+  use it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,9 @@ Engine internals are private.
 
 Read them in this order:
 
+- [ARCHITECTURE.md](ARCHITECTURE.md): canonical Freven platform architecture
+  and ownership vocabulary for engine, SDK, experiences, Vanilla, mods,
+  content packs, script packs, standalone products, and save/world state
 - [WASM_AUTHORING.md](WASM_AUTHORING.md): recommended Wasm authoring paths for
   neutral guests and explicit world-stack guests
 - [NEUTRAL_GUEST_CONTRACT_v1.md](NEUTRAL_GUEST_CONTRACT_v1.md): canonical

--- a/docs/WASM_AUTHORING.md
+++ b/docs/WASM_AUTHORING.md
@@ -11,6 +11,9 @@ Current authoring is split into two explicit layers:
   worldgen, character controllers, client-control providers, and world runtime
   services
 
+For the broader engine / SDK / experience / mod / content-pack / standalone
+product boundary model, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
 Most gameplay mods and current Vanilla-style authoring should use
 `freven_world_guest_sdk`.
 


### PR DESCRIPTION
## Summary

Documents the canonical Freven architecture and ownership vocabulary for rc10.

Adds `docs/ARCHITECTURE.md` as the source of truth for the high-level boundaries between:

- engine / platform
- SDK
- game / gameplay SDK roots
- experiences
- Vanilla
- standalone products
- mods
- content packs
- future script packs
- save/world state

Also links the new architecture document from the root README, docs index, and Wasm authoring guide.

## Why

Freven is becoming a platform, not just a single game or a thin mod loader.

Before rc10 adds data-driven visual assets, layered overrides, patch/merge semantics, and Vanilla visual content packs, the SDK needs one clear vocabulary for what each layer owns and what it must not own.

This keeps engine details out of creator-facing APIs, keeps Vanilla out of engine core, and makes zero-Vanilla standalone products a first-class target.

## Scope

Docs only.

This PR intentionally does not define the full schemas for manifest/config/content/assets/save state, visual asset model, layered overrides, or content patch/merge semantics. Those remain separate rc10 issues that should build on this vocabulary.

## Validation

- `git --no-pager diff --cached --check`
- `rg -n 'ARCHITECTURE.md|Engine / platform|Game / gameplay SDK roots|Content pack|Standalone product|Save/world state|zero-Vanilla|renderer-internal slots' README.md docs`

Closes frevenengine/freven-sdk#77.
Part of frevenengine/freven-devkit#90.
