### PR TITLE
Document game-owned content authoring profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ For the canonical architecture and ownership vocabulary, see
 engine / SDK / experience / Vanilla / mod / content-pack /
 standalone-product boundaries used by the rc10 visual/data foundation work.
 
+For the game-owned authoring profile boundary, see
+[docs/CONTENT_AUTHORING_PROFILES_v1.md](docs/CONTENT_AUTHORING_PROFILES_v1.md).
+That document explains how a game such as Vanilla can provide a friendly
+blocktype/worldproperty workflow while the engine still consumes the generic
+canonical content graph.
+
 The current long-term direction is:
 
 - **engine/platform layer**: neutral runtime/platform substrate

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,7 +28,7 @@ semantics are defined by follow-up documents.
 | Layer | Owns | Does not own |
 | --- | --- | --- |
 | Engine / platform | runtime host, renderer, networking, storage, asset resolver, scheduling, sandboxing, diagnostics, cache, authoritative apply paths | Vanilla gameplay, first-party content, author-facing schemas, mod policy decisions baked as gameplay meaning |
-| SDK | public contracts, schemas, namespaced identities, guest APIs, capability vocabulary, author-facing validation model | engine internals, renderer slots, Bevy/wgpu types, concrete Vanilla content |
+| SDK | public contracts, schemas, namespaced identities, guest APIs, capability vocabulary, author-facing validation model, authoring-profile boundary vocabulary | engine internals, renderer slots, Bevy/wgpu types, concrete Vanilla content, game-specific profile implementation |
 | Game / gameplay SDK roots | explicit world, volumetric, block, avatar, gameplay-state, item, UI, input, effect, and save contracts above the neutral SDK roots | neutral platform ownership, renderer implementation, first-party Vanilla semantics |
 | Experience | a concrete playable root such as Vanilla, a minigame, a total conversion, or a standalone game experience | engine implementation details |
 | Vanilla | first-party reference experience, default gameplay/content/style, reference integration patterns | platform ownership, required dependency for all games |
@@ -121,6 +121,27 @@ A content pack is the right shape for simple visual/content changes that do not
 need executable code. It must not get runtime authority just because it can
 provide data or assets.
 
+### Content authoring profile
+
+A content authoring profile is a game/mode-owned source schema that compiles or
+expands into Freven's canonical content graph.
+
+The engine owns the canonical graph and runtime registries. It must not hardcode
+Vanilla's blocktype/worldproperty workflow or any other game's source schema.
+
+Examples of possible profiles include:
+
+- a Vanilla-owned blocktypes/worldproperties/shapes workflow;
+- a resource-pack-style convention;
+- a prototype-stage workflow;
+- a standalone game's custom data schema.
+
+Profiles are selected explicitly by experiences or stacks. Mods can target the
+selected game profile, the low-level canonical graph, or both when they opt in.
+
+The SDK boundary is defined in
+[CONTENT_AUTHORING_PROFILES_v1.md](CONTENT_AUTHORING_PROFILES_v1.md).
+
 ### Script pack
 
 A script pack is a future creator-friendly executable layer for languages above
@@ -169,8 +190,9 @@ A typical Freven launch resolves in this conceptual order:
 2. Select an experience or experience stack.
 3. Resolve declared packages, dependencies, trust policy, and active sides.
 4. Resolve config schemas and active config values.
-5. Resolve content data and visual assets through deterministic layer rules.
-6. Build host-internal load plans, caches, and runtime handles.
+5. Compile or expand any selected game-owned authoring profile into the canonical content graph.
+6. Resolve content data and visual assets through deterministic layer rules.
+7. Build host-internal load plans, caches, and runtime handles.
 7. Start the server/client runtime with only the resolved public contracts.
 8. Persist runtime state into save/world state, not back into shipped content.
 
@@ -215,7 +237,7 @@ architecture vocabulary instead of redefining it.
 - Put package identity and capability requests in manifests, not active runtime
   config.
 - Put active values in experience/stack config, not `mod.toml`.
-- Put authored content in content data and assets, not save/world state.
+- Put authored content in content data/assets or a selected game-owned authoring profile, not save/world state.
 - Put generated resolver output in cache/load-plan data, not authored source.
 - Keep every override, patch, and dependency decision explicit and diagnosable.
 - Prefer namespaced keys over renderer slots or raw host ids in public APIs.

--- a/docs/CONTENT_AUTHORING_PROFILES_v1.md
+++ b/docs/CONTENT_AUTHORING_PROFILES_v1.md
@@ -1,0 +1,282 @@
+# Content Authoring Profiles v1
+
+This document defines the SDK-level boundary for game-owned content authoring
+profiles.
+
+Freven has one generic canonical content graph for engine/runtime consumption.
+Games, modes, total conversions, and standalone products may define their own
+creator-facing source schemas on top of that graph.
+
+Vanilla may choose a blocktypes/worldproperties/shapes workflow. Another game may
+choose a prototype pipeline, a resource-pack convention, or a custom domain
+schema.
+
+The engine must not hardcode Vanilla's authoring format.
+
+## Core model
+
+The intended pipeline is:
+
+    Game/mode authoring source
+      -> profile compiler / expander / validator
+    Canonical Freven content graph
+      -> engine/runtime registries, load plans, caches, and handles
+
+The authoring profile is the friendly source layer. The canonical graph is the
+stable backend boundary.
+
+A profile can make authoring pleasant without creating a second runtime content
+model.
+
+## Why this exists
+
+The canonical content graph is good for:
+
+- deterministic loading;
+- layer/override resolution;
+- validation;
+- source provenance;
+- package fingerprints;
+- generated cache;
+- runtime load plans;
+- stable diagnostics.
+
+It is not always the best human-facing editing format.
+
+A Vanilla block author should be able to think in terms of a blocktype, variant
+groups, textures, shapes, drops, tags, sounds, and gameplay behavior hooks. They
+should not need to understand engine registry tables, renderer slots, internal
+material slots, atlas pages, or generated cache files.
+
+## Ownership
+
+| Layer | Owns |
+| --- | --- |
+| Engine/runtime | loading, resolving, validating canonical graph, renderer/backend registries, cache, runtime handles |
+| SDK | public vocabulary for authoring profile contracts, canonical graph boundary, provenance, diagnostics expectations |
+| Game/mode/profile | friendly source schema, conventions, defaults, compile rules, profile-specific validation |
+| Boot/DevKit | profile compile/check/explain/update tooling |
+| Mods/content packs | source files targeting the selected game/mode profile or low-level canonical graph by explicit choice |
+
+## Canonical content graph
+
+The canonical graph is the backend representation consumed by engine/runtime and
+tooling.
+
+Current rc10 graph areas include:
+
+- texture declarations;
+- material declarations;
+- model declarations;
+- block visual bindings;
+- content families and deterministic generated entries;
+- block tags;
+- content patch/merge operations;
+- layered content/asset overrides.
+
+Future graph areas may include items, recipes, loot, entities, behaviors, UI,
+effects, sounds, biome data, or other gameplay content.
+
+The graph must remain:
+
+- deterministic;
+- namespaced;
+- explicit after expansion;
+- validated before runtime use;
+- diagnosable back to authored source;
+- free of renderer/runtime ids in author-authored files.
+
+## Authoring profiles
+
+An authoring profile is a game/mode-owned source schema plus compile/expand rules
+that produce canonical graph declarations.
+
+Examples:
+
+- Vanilla blocktype profile:
+  - blocktypes/
+  - worldproperties/
+  - shapes/
+  - textures/
+  - tags/
+- Resource-pack-style profile:
+  - conventional textures/models/sounds folders;
+  - pack metadata;
+  - override layers.
+- Prototype-style profile:
+  - data/prototype entrypoints;
+  - deterministic staged expansion;
+  - final canonical graph output.
+- Custom standalone game profile:
+  - product-specific entities, items, visuals, rules, or data tables.
+
+Profiles are optional. A small package may target the canonical graph directly.
+
+## Profile selection
+
+An experience or stack should be able to select which profile owns a source tree.
+
+Conceptually:
+
+    [content]
+    root = "content"
+    manifest = "content.manifest"
+
+    [content.authoring]
+    profile = "freven.vanilla:blocktypes_v1"
+
+The exact manifest/config shape is intentionally left to implementation issues.
+The SDK boundary is:
+
+- profile selection must be explicit;
+- profile ids must be namespaced;
+- profile versioning must be visible;
+- profile output must compile to the canonical graph;
+- diagnostics must report both authoring source and canonical output where useful.
+
+## Source provenance
+
+Profile compilers must preserve provenance.
+
+Diagnostics should be able to answer:
+
+- which profile was selected;
+- which source file was read;
+- which authoring kind was parsed;
+- which field path failed;
+- which canonical declaration was generated;
+- which semantic key was produced;
+- which included/generated source path was involved;
+- what command can explain or fix the issue.
+
+Example diagnostic shape:
+
+    error: duplicate generated material key
+    profile: freven.vanilla:blocktypes_v1
+    source: content/blocktypes/grass.toml
+    field: textures.side
+    generated declaration: materials
+    key: freven.vanilla:block/grass_side
+    first source: content/blocktypes/grass.toml
+    second source: content/blocktypes/soil.toml
+    fix: rename the generated key, override intentionally, or move shared material ownership to a common source file
+
+## Low-level canonical authoring remains valid
+
+The canonical content manifest remains a valid advanced authoring format.
+
+It is appropriate for:
+
+- tests;
+- generated output;
+- low-level content packs;
+- engine feature validation;
+- advanced mods;
+- bridge layers from custom tools;
+- profiles that intentionally expose graph-level control.
+
+But it should not be the only authoring UX that games can offer to modders.
+
+## Vanilla profile direction
+
+Vanilla should own its own friendly schema.
+
+A future Vanilla profile may include source files such as:
+
+    content/blocktypes/rock.toml
+    content/blocktypes/soil.toml
+    content/blocktypes/glass.toml
+    content/worldproperties/rock.toml
+    content/worldproperties/fertility.toml
+    content/worldproperties/grass_coverage.toml
+    content/shapes/block/cube.toml
+    content/shapes/block/topsoil.toml
+    content/tags/terrain.toml
+
+Those files are Vanilla-owned authoring source. They compile into the same
+canonical Freven graph consumed by the engine.
+
+A zero-Vanilla standalone game must be able to ignore this profile and use its
+own profile or the canonical graph directly.
+
+## Mods and compatibility
+
+A mod should declare what it targets:
+
+- the engine/SDK canonical graph directly;
+- a selected game-owned profile;
+- both, when it intentionally mixes low-level and profile-level authoring.
+
+A Vanilla mod targeting the Vanilla blocktype profile should not silently become
+dependent on engine internals. A standalone game mod should not be forced to use
+Vanilla profile files.
+
+Compatibility should be checked at the profile boundary:
+
+- profile id;
+- profile version;
+- generated canonical key stability;
+- dependency namespaces;
+- profile-specific feature gates;
+- canonical graph compatibility.
+
+## Generated output and cache
+
+Profile compiler output may be materialized for inspection, packaging, caching,
+or debugging.
+
+Generated output must not become the human source of truth unless explicitly
+declared by the profile.
+
+Rules:
+
+- authored profile source stays source;
+- canonical generated graph can be rebuilt;
+- generated cache is host/tooling output;
+- runtime load plans are not authoring source;
+- save/world state is not source;
+- renderer handles, material slots, atlas coordinates, and runtime ids are not
+  valid authoring fields.
+
+## Relation to existing SDK docs
+
+This document does not replace the existing data-driven authoring layer.
+
+Instead:
+
+- this document defines the profile boundary;
+- DATA_DRIVEN_AUTHORING_LAYER_v1.md describes practical friendly source patterns;
+- MODULAR_CONTENT_MANIFESTS_v1.md describes explicit include organization for
+  canonical manifest source;
+- CONTENT_VARIANT_FAMILY_SCHEMA_v1.md describes deterministic family expansion;
+- CONTENT_PATCH_MERGE_v1.md describes semantic patch/merge rules;
+- visual/material/model docs define canonical visual graph semantics.
+
+## Non-goals
+
+This document does not implement:
+
+- Vanilla blocktype schema;
+- Boot content compile command;
+- DevKit templates;
+- scripting language bindings;
+- every future gameplay schema;
+- runtime hot reload;
+- save migration format.
+
+Those belong in implementation issues.
+
+## Acceptance checklist
+
+A new authoring profile design should answer:
+
+- Who owns the profile?
+- How is the profile selected?
+- What source files does it read?
+- What canonical declarations does it produce?
+- How are generated keys derived?
+- How are overrides and layers handled?
+- How is provenance preserved?
+- How are errors explained?
+- Can another game ignore this profile?
+- Are engine/runtime ids kept out of authoring source?

--- a/docs/DATA_DRIVEN_AUTHORING_LAYER_v1.md
+++ b/docs/DATA_DRIVEN_AUTHORING_LAYER_v1.md
@@ -32,6 +32,8 @@ It builds on:
   patch, append, disable, compatibility, and diagnostics model;
 - [MODULAR_CONTENT_MANIFESTS_v1.md](MODULAR_CONTENT_MANIFESTS_v1.md):
   explicit deterministic includes for splitting large content packs across files;
+- [CONTENT_AUTHORING_PROFILES_v1.md](CONTENT_AUTHORING_PROFILES_v1.md):
+  game/mode-owned source schemas that compile to the canonical content graph;
 - [CREATOR_CONTENT_SCHEMA_v1.md](CREATOR_CONTENT_SCHEMA_v1.md): creator-friendly
   schema direction for common content files;
 - [SHADER_EFFECT_BOUNDARY_v1.md](SHADER_EFFECT_BOUNDARY_v1.md): shader/effect
@@ -49,6 +51,12 @@ The authoring layer is a friendly source layer.
 It does not create a second content model. Authoring files compile into the same
 semantic content entries and patch/merge operations defined by
 [CONTENT_PATCH_MERGE_v1.md](CONTENT_PATCH_MERGE_v1.md).
+
+This document describes practical friendly source patterns. It does not require
+every game to use the same source schema. Game-owned authoring profiles are
+allowed to define their own blocktype, prototype, resource-pack, or custom
+source layout as long as the resolved output is the canonical Freven content
+graph described by [CONTENT_AUTHORING_PROFILES_v1.md](CONTENT_AUTHORING_PROFILES_v1.md).
 
 A beginner-friendly file may be concise, but the resolved result must still be
 explicit, namespaced, validated, deterministic, and diagnosable.


### PR DESCRIPTION
## Summary

Documents the SDK-level boundary for game-owned content authoring profiles.

This keeps the engine/runtime focused on a generic canonical content graph while allowing games and modes to define their own creator-facing source schemas on top.

## What changed

- Added `docs/CONTENT_AUTHORING_PROFILES_v1.md`.
- Defined authoring profiles as game/mode-owned source schemas that compile or expand into the canonical Freven content graph.
- Clarified that the engine must not hardcode Vanilla's blocktype/worldproperty workflow.
- Documented how Vanilla can own a Vintage-Story-style blocktypes/worldproperties/shapes profile while other games can choose Factorio-like, Minecraft-like, or custom workflows.
- Documented provenance expectations from authoring source to generated canonical declarations.
- Updated README, architecture docs, and data-driven authoring docs to link the new boundary.

## Validation

- markdown local link check
- cargo +stable fmt --all -- --check
- cargo +stable --locked test --workspace
- cargo +stable --locked clippy --workspace --all-targets -- -D warnings
- git --no-pager diff --check
- coverage grep for authoring profile, canonical content graph, game-owned, Vanilla, blocktypes/worldproperties, runtime ids, and renderer slots

Closes frevenengine/freven-sdk#111
